### PR TITLE
feat(simulations): add simulation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,6 +955,384 @@ La modification est masquée ou rendue indisponible lorsque :
 
 ---
 
+## Historique des simulations
+
+L’application permet de consulter l’historique des simulations associées à un satellite.
+
+Chaque simulation correspond à un lancement de calcul effectué depuis l’application :
+
+- simulation orbitale simple ;
+- manœuvre de transfert de Hohmann.
+
+L’historique permet de retrouver les simulations déjà lancées, d’identifier leur type, de consulter leurs résultats principaux et d’accéder au détail complet d’une simulation.
+
+---
+
+### Objectif fonctionnel
+
+L’objectif de cette fonctionnalité est de permettre à un utilisateur authentifié de consulter les simulations déjà réalisées sur un satellite.
+
+Une simulation conserve :
+
+- le satellite concerné ;
+- la mission associée ;
+- le type de simulation ;
+- le statut du run ;
+- la date de lancement ;
+- l’utilisateur ayant lancé la simulation ;
+- les paramètres utilisés au moment du lancement ;
+- les résultats calculés ;
+- les données de visualisation.
+
+Les simulations sont conservées sans limitation de durée et ne sont pas modifiables depuis l’application.
+
+---
+
+### Types de simulations historisées
+
+| Type | Description |
+|---|---|
+| `ORBIT` | Simulation orbitale simple à partir des paramètres orbitaux du satellite |
+| `HOHMANN` | Manœuvre de transfert de Hohmann vers une altitude cible |
+
+---
+
+### Endpoints API
+
+| Méthode | Endpoint | Description | Rôles autorisés |
+|---|---|---|---|
+| `GET` | `/api/satellites/{id}/simulations` | Consulter l’historique des simulations d’un satellite | ADMIN, OPERATEUR, LECTEUR |
+| `GET` | `/api/simulations/{id}` | Consulter le détail complet d’une simulation | ADMIN, OPERATEUR, LECTEUR |
+
+Les utilisateurs doivent être authentifiés pour consulter l’historique ou le détail d’une simulation.
+
+---
+
+### Exemple de requête - Historique d’un satellite
+
+```http
+GET /api/satellites/3/simulations
+Authorization: Bearer <token>
+```
+
+Exemple de réponse :
+
+```json
+[
+  {
+    "id": 21,
+    "missionId": 4,
+    "missionName": "Mission to the MOOOOON",
+    "satelliteId": 3,
+    "satelliteName": "LunaSat-03",
+    "type": "HOHMANN",
+    "status": "SUCCESS",
+    "createdAt": "2026-06-09T23:26:44.438922",
+    "createdBy": "admin@finalspace.com",
+    "inputAltitudeKm": 500.0,
+    "targetAltitudeKm": 800.0,
+    "orbitalPeriodMinutes": null,
+    "averageVelocityKmS": null,
+    "orbitShape": null,
+    "deltaVTotalMS": 161.0,
+    "transferTimeMinutes": 48.79
+  }
+]
+```
+
+Les simulations sont retournées par ordre chronologique décroissant, de la plus récente à la plus ancienne.
+
+---
+
+### Exemple de requête - Détail d’une simulation
+
+```http
+GET /api/simulations/21
+Authorization: Bearer <token>
+```
+
+Exemple de réponse :
+
+```json
+{
+  "id": 21,
+  "missionId": 4,
+  "missionName": "Mission to the MOOOOON",
+  "satelliteId": 3,
+  "satelliteName": "LunaSat-03",
+  "type": "HOHMANN",
+  "status": "SUCCESS",
+  "inputMassKg": 850.0,
+  "inputAltitudeKm": 500.0,
+  "inputInclinationDeg": 95.0,
+  "inputEccentricity": 0.4,
+  "orbitalPeriodMinutes": null,
+  "averageVelocityKmS": null,
+  "orbitShape": null,
+  "targetAltitudeKm": 800.0,
+  "deltaV1MS": 80.93,
+  "deltaV2MS": 80.07,
+  "deltaVTotalMS": 161.0,
+  "transferTimeMinutes": 48.79,
+  "plotDataJson": "{...}",
+  "createdAt": "2026-06-09T23:26:44.438922",
+  "createdBy": "admin@finalspace.com"
+}
+```
+
+---
+
+### Données affichées dans l’historique
+
+La page détail d’un satellite affiche une section `Historique des simulations`.
+
+Cette section présente les informations suivantes :
+
+| Colonne | Description |
+|---|---|
+| Date | Date de lancement de la simulation |
+| Type | Type de simulation : orbite ou Hohmann |
+| Statut | Statut du run |
+| Auteur | Utilisateur ayant lancé la simulation |
+| Résumé | Résultat synthétique selon le type de simulation |
+| Action | Accès au détail de la simulation |
+
+Pour une simulation `ORBIT`, le résumé affiche notamment :
+
+- la période orbitale ;
+- la vitesse moyenne ;
+- la forme de l’orbite.
+
+Pour une simulation `HOHMANN`, le résumé affiche notamment :
+
+- le Δv total ;
+- la durée estimée du transfert.
+
+---
+
+### Page détail d’une simulation
+
+L’application propose une page dédiée au détail d’une simulation :
+
+```text
+/simulations/{id}
+```
+
+Cette page affiche :
+
+- le type de simulation ;
+- le statut ;
+- la mission associée ;
+- le satellite concerné ;
+- la date de lancement ;
+- l’auteur ;
+- les paramètres figés utilisés au lancement ;
+- les résultats calculés ;
+- une visualisation 2D simplifiée ;
+- les données techniques de visualisation.
+
+Pour une simulation orbitale, la page affiche les résultats orbitaux.
+
+Pour une manœuvre de Hohmann, la page affiche les résultats de transfert :
+
+- Δv départ ;
+- Δv arrivée ;
+- Δv total ;
+- durée estimée du transfert ;
+- orbite initiale ;
+- orbite cible ;
+- arc de transfert.
+
+---
+
+### Règles métier
+
+| Règle | Description |
+|---|---|
+| Conservation | Les simulations sont conservées sans limitation de durée |
+| Immutabilité | Les simulations ne peuvent pas être modifiées |
+| Suppression interdite | Les simulations ne peuvent pas être supprimées depuis l’application |
+| Consultation après clôture | Les simulations restent consultables même si la mission est clôturée |
+| Consultation après désactivation | Les simulations restent consultables même si le satellite est inactif |
+| Tri | Les simulations sont listées de la plus récente à la plus ancienne |
+| Détail | Chaque simulation peut être consultée individuellement |
+| Sécurité | ADMIN, OPERATEUR et LECTEUR peuvent consulter l’historique |
+| Authentification | Un utilisateur non authentifié ne peut pas consulter l’historique |
+
+---
+
+### Choix d’implémentation
+
+L’historique s’appuie sur l’entité `SimulationRun`.
+
+Cette entité centralise les simulations de différents types grâce au champ `type`.
+
+Les simulations orbitales et les manœuvres de Hohmann partagent donc une structure commune :
+
+- identifiant du run ;
+- mission associée ;
+- satellite associé ;
+- type ;
+- statut ;
+- auteur ;
+- date de création ;
+- paramètres figés ;
+- résultats ;
+- données de visualisation.
+
+Deux DTO sont utilisés pour distinguer les besoins d’affichage :
+
+| DTO | Utilisation |
+|---|---|
+| `SimulationListItemResponse` | Affichage de la liste des simulations |
+| `SimulationDetailResponse` | Affichage du détail complet d’une simulation |
+
+Ce découpage évite de retourner toutes les données techniques dans la liste, notamment le champ `plotDataJson`, qui peut être volumineux.
+
+---
+
+### Repository
+
+Les requêtes principales utilisées sont :
+
+```java
+List<SimulationRun> findBySatelliteIdOrderByCreatedAtDesc(Long satelliteId);
+
+List<SimulationRun> findByMissionIdOrderByCreatedAtDesc(Long missionId);
+```
+
+La requête utilisée pour l’affichage actuel est l’historique par satellite.
+
+L’historique par mission est prévu dans le modèle mais n’est pas encore exposé côté interface utilisateur.
+
+---
+
+### Gestion des erreurs
+
+| Cas | Réponse |
+|---|---|
+| Satellite introuvable | `404 Not Found` |
+| Simulation introuvable | `404 Not Found` |
+| Utilisateur non authentifié | `401 Unauthorized` |
+| Utilisateur sans droit | `403 Forbidden` |
+
+---
+
+### Frontend
+
+Côté frontend, l’historique est intégré à la page détail d’un satellite.
+
+La page satellite charge automatiquement l’historique via :
+
+```text
+GET /api/satellites/{id}/simulations
+```
+
+Après le lancement d’une simulation orbitale ou d’une manœuvre de Hohmann, l’historique est rechargé automatiquement afin d’afficher le nouveau run.
+
+Une page de détail est également disponible via :
+
+```text
+/simulations/{id}
+```
+
+Cette page appelle :
+
+```text
+GET /api/simulations/{id}
+```
+
+---
+
+### États d’affichage
+
+L’interface gère les états suivants :
+
+| État | Description |
+|---|---|
+| Chargement | Affichage d’un message pendant le chargement |
+| Vide | Message si aucune simulation n’existe pour le satellite |
+| Erreur | Message si l’historique ou le détail ne peut pas être chargé |
+| Succès | Affichage de la liste ou du détail |
+| Accès refusé | Redirection vers la page `forbidden` en cas de 403 |
+
+---
+
+### Tests réalisés
+
+Les tests backend couvrent :
+
+- la récupération de l’historique d’un satellite ;
+- le tri des simulations par date décroissante ;
+- le cas d’un historique vide ;
+- le cas d’un satellite introuvable ;
+- la récupération du détail d’une simulation ;
+- le cas d’une simulation introuvable ;
+- l’accès ADMIN ;
+- l’accès OPERATEUR ;
+- l’accès LECTEUR ;
+- le refus d’un utilisateur non authentifié.
+
+Résultat d’exécution backend :
+
+```text
+Tests run: 168, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+Le build frontend a également été validé :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+### Validation fonctionnelle
+
+La fonctionnalité a été validée manuellement dans le navigateur.
+
+Cas validés :
+
+- l’historique apparaît sur la page détail satellite ;
+- les simulations sont affichées dans un tableau ;
+- les simulations orbitales et Hohmann sont distinguées ;
+- le résumé affiché dépend du type de simulation ;
+- le lien `Voir détail` ouvre la page de détail ;
+- la page détail affiche les paramètres et les résultats ;
+- l’accès à l’historique fonctionne avec le rôle `LECTEUR`.
+
+---
+
+### Limites actuelles
+
+La fonctionnalité ne couvre pas encore :
+
+- l’historique global d’une mission côté interface ;
+- la comparaison avancée entre plusieurs simulations ;
+- la pagination ;
+- le filtrage par type ;
+- l’export des résultats ;
+- le rejeu d’une simulation existante ;
+- la duplication d’une simulation.
+
+Ces points sont prévus hors périmètre de l’US14 ou dans des user stories futures.
+
+---
+
+### Perspectives d’évolution
+
+Évolutions possibles :
+
+- ajouter un historique par mission ;
+- ajouter une pagination côté backend et frontend ;
+- ajouter des filtres par type de simulation ;
+- ajouter une comparaison visuelle entre plusieurs simulations ;
+- ajouter l’export CSV/PDF ;
+- ajouter une page dédiée à l’ensemble des simulations d’une mission.
+
+---
+
 ## Dashboard mission
 
 L’application permet de consulter un dashboard synthétique pour une mission.

--- a/backend/src/main/java/com/finalspace/backend/simulation/controller/SimulationController.java
+++ b/backend/src/main/java/com/finalspace/backend/simulation/controller/SimulationController.java
@@ -2,12 +2,16 @@ package com.finalspace.backend.simulation.controller;
 
 import com.finalspace.backend.simulation.dto.SimulationResponse;
 import com.finalspace.backend.simulation.dto.HohmannTransferRequest;
+import com.finalspace.backend.simulation.dto.SimulationDetailResponse;
+import com.finalspace.backend.simulation.dto.SimulationListItemResponse;
 import com.finalspace.backend.simulation.service.SimulationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,5 +37,19 @@ public class SimulationController {
             Authentication authentication
     ) {
         return simulationService.launchHohmannTransfer(id, request, authentication.getName());
+    }
+
+    @GetMapping("/satellites/{id}/simulations")
+    public List<SimulationListItemResponse> findSimulationsBySatellite(
+            @PathVariable Long id
+    ) {
+        return simulationService.findSimulationsBySatellite(id);
+    }
+
+    @GetMapping("/simulations/{id}")
+    public SimulationDetailResponse findSimulationById(
+            @PathVariable Long id
+    ) {
+        return simulationService.findSimulationById(id);
     }
 }

--- a/backend/src/main/java/com/finalspace/backend/simulation/dto/SimulationDetailResponse.java
+++ b/backend/src/main/java/com/finalspace/backend/simulation/dto/SimulationDetailResponse.java
@@ -1,0 +1,36 @@
+package com.finalspace.backend.simulation.dto;
+
+import com.finalspace.backend.simulation.SimulationStatus;
+import com.finalspace.backend.simulation.SimulationType;
+
+import java.time.LocalDateTime;
+
+public record SimulationDetailResponse(
+        Long id,
+        Long missionId,
+        String missionName,
+        Long satelliteId,
+        String satelliteName,
+        SimulationType type,
+        SimulationStatus status,
+
+        Double inputMassKg,
+        Double inputAltitudeKm,
+        Double inputInclinationDeg,
+        Double inputEccentricity,
+
+        Double orbitalPeriodMinutes,
+        Double averageVelocityKmS,
+        String orbitShape,
+
+        Double targetAltitudeKm,
+        Double deltaV1MS,
+        Double deltaV2MS,
+        Double deltaVTotalMS,
+        Double transferTimeMinutes,
+
+        String plotDataJson,
+        LocalDateTime createdAt,
+        String createdBy
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/simulation/dto/SimulationListItemResponse.java
+++ b/backend/src/main/java/com/finalspace/backend/simulation/dto/SimulationListItemResponse.java
@@ -1,0 +1,29 @@
+package com.finalspace.backend.simulation.dto;
+
+import com.finalspace.backend.simulation.SimulationStatus;
+import com.finalspace.backend.simulation.SimulationType;
+
+import java.time.LocalDateTime;
+
+public record SimulationListItemResponse(
+        Long id,
+        Long missionId,
+        String missionName,
+        Long satelliteId,
+        String satelliteName,
+        SimulationType type,
+        SimulationStatus status,
+        LocalDateTime createdAt,
+        String createdBy,
+
+        Double inputAltitudeKm,
+        Double targetAltitudeKm,
+
+        Double orbitalPeriodMinutes,
+        Double averageVelocityKmS,
+        String orbitShape,
+
+        Double deltaVTotalMS,
+        Double transferTimeMinutes
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/simulation/service/SimulationService.java
+++ b/backend/src/main/java/com/finalspace/backend/simulation/service/SimulationService.java
@@ -2,10 +2,18 @@ package com.finalspace.backend.simulation.service;
 
 import com.finalspace.backend.simulation.dto.SimulationResponse;
 import com.finalspace.backend.simulation.dto.HohmannTransferRequest;
+import com.finalspace.backend.simulation.dto.SimulationDetailResponse;
+import com.finalspace.backend.simulation.dto.SimulationListItemResponse;
+
+import java.util.List;
 
 public interface SimulationService {
 
     SimulationResponse launchOrbitSimulation(Long satelliteId, String createdBy);
 
     SimulationResponse launchHohmannTransfer(Long satelliteId, HohmannTransferRequest request, String createdBy);
+
+    List<SimulationListItemResponse> findSimulationsBySatellite(Long satelliteId);
+
+    SimulationDetailResponse findSimulationById(Long simulationId);
 }

--- a/backend/src/main/java/com/finalspace/backend/simulation/service/impl/SimulationServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/simulation/service/impl/SimulationServiceImpl.java
@@ -10,6 +10,8 @@ import com.finalspace.backend.simulation.SimulationRun;
 import com.finalspace.backend.simulation.SimulationRunRepository;
 import com.finalspace.backend.simulation.SimulationStatus;
 import com.finalspace.backend.simulation.SimulationType;
+import com.finalspace.backend.simulation.dto.SimulationDetailResponse;
+import com.finalspace.backend.simulation.dto.SimulationListItemResponse;
 import com.finalspace.backend.simulation.dto.OrbitSimulationResult;
 import com.finalspace.backend.simulation.dto.SimulationResponse;
 import com.finalspace.backend.simulation.dto.HohmannTransferRequest;
@@ -20,6 +22,8 @@ import com.finalspace.backend.simulation.service.SimulationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import java.time.LocalDateTime;
 
@@ -138,6 +142,76 @@ public class SimulationServiceImpl implements SimulationService {
 
     private SimulationResponse toResponse(SimulationRun run) {
         return new SimulationResponse(
+                run.getId(),
+                run.getMission().getId(),
+                run.getMission().getName(),
+                run.getSatellite().getId(),
+                run.getSatellite().getName(),
+                run.getType(),
+                run.getStatus(),
+                run.getInputMassKg(),
+                run.getInputAltitudeKm(),
+                run.getInputInclinationDeg(),
+                run.getInputEccentricity(),
+                run.getOrbitalPeriodMinutes(),
+                run.getAverageVelocityKmS(),
+                run.getOrbitShape(),
+                run.getTargetAltitudeKm(),
+                run.getDeltaV1MS(),
+                run.getDeltaV2MS(),
+                run.getDeltaVTotalMS(),
+                run.getTransferTimeMinutes(),
+                run.getPlotDataJson(),
+                run.getCreatedAt(),
+                run.getCreatedBy()
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SimulationListItemResponse> findSimulationsBySatellite(Long satelliteId) {
+        if (!satelliteRepository.existsById(satelliteId)) {
+            throw new ResourceNotFoundException("Satellite introuvable");
+        }
+
+        return simulationRunRepository.findBySatelliteIdOrderByCreatedAtDesc(satelliteId)
+                .stream()
+                .map(this::toListItemResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SimulationDetailResponse findSimulationById(Long simulationId) {
+        SimulationRun run = simulationRunRepository.findById(simulationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Simulation introuvable"));
+
+        return toDetailResponse(run);
+    }
+
+    private SimulationListItemResponse toListItemResponse(SimulationRun run) {
+        return new SimulationListItemResponse(
+                run.getId(),
+                run.getMission().getId(),
+                run.getMission().getName(),
+                run.getSatellite().getId(),
+                run.getSatellite().getName(),
+                run.getType(),
+                run.getStatus(),
+                run.getCreatedAt(),
+                run.getCreatedBy(),
+                run.getInputAltitudeKm(),
+                run.getTargetAltitudeKm(),
+                run.getOrbitalPeriodMinutes(),
+                run.getAverageVelocityKmS(),
+                run.getOrbitShape(),
+                run.getDeltaVTotalMS(),
+                run.getTransferTimeMinutes()
+        );
+    }
+
+    private SimulationDetailResponse toDetailResponse(SimulationRun run) {
+        return new SimulationDetailResponse(
                 run.getId(),
                 run.getMission().getId(),
                 run.getMission().getName(),

--- a/backend/src/test/java/com/finalspace/backend/security/SimulationAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/finalspace/backend/security/SimulationAuthorizationIntegrationTest.java
@@ -337,4 +337,136 @@ class SimulationAuthorizationIntegrationTest {
                         .content(hohmannRequestJson(-100.0)))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void shouldAllowAdminToListSatelliteSimulationHistory() throws Exception {
+        String adminToken = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(post("/api/satellites/" + satellite.getId() + "/simulations/orbit")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/satellites/" + satellite.getId() + "/simulations/hohmann")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(hohmannRequestJson(800.0)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/api/satellites/" + satellite.getId() + "/simulations")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].id").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].type").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].createdAt").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].createdBy").exists());
+    }
+
+    @Test
+    void shouldAllowReaderToListSatelliteSimulationHistory() throws Exception {
+        String adminToken = loginAndGetToken("admin@finalspace.com", "admin123");
+        String readerToken = loginAndGetToken("reader@finalspace.com", "reader123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(post("/api/satellites/" + satellite.getId() + "/simulations/orbit")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/api/satellites/" + satellite.getId() + "/simulations")
+                        .header("Authorization", "Bearer " + readerToken))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(1));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenListingHistoryForUnknownSatellite() throws Exception {
+        String adminToken = loginAndGetToken("admin@finalspace.com", "admin123");
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/api/satellites/99999/simulations")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectSimulationHistoryListWithoutToken() throws Exception {
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/api/satellites/" + satellite.getId() + "/simulations"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldAllowAdminToGetSimulationDetail() throws Exception {
+        String adminToken = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createActiveSatellite();
+
+        MvcResult creationResult = mockMvc.perform(post("/api/satellites/" + satellite.getId() + "/simulations/hohmann")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(hohmannRequestJson(800.0)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode creationResponse = jsonMapper.readTree(creationResult.getResponse().getContentAsString());
+        long simulationId = creationResponse.get("id").asLong();
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/api/simulations/" + simulationId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(simulationId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.type").value("HOHMANN"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("SUCCESS"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.satelliteId").value(satellite.getId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.targetAltitudeKm").value(800.0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.deltaVTotalMS").isNumber())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.plotDataJson").exists());
+    }
+
+    @Test
+    void shouldAllowReaderToGetSimulationDetail() throws Exception {
+        String adminToken = loginAndGetToken("admin@finalspace.com", "admin123");
+        String readerToken = loginAndGetToken("reader@finalspace.com", "reader123");
+        Satellite satellite = createActiveSatellite();
+
+        MvcResult creationResult = mockMvc.perform(post("/api/satellites/" + satellite.getId() + "/simulations/orbit")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode creationResponse = jsonMapper.readTree(creationResult.getResponse().getContentAsString());
+        long simulationId = creationResponse.get("id").asLong();
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/api/simulations/" + simulationId)
+                        .header("Authorization", "Bearer " + readerToken))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(simulationId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.type").value("ORBIT"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.plotDataJson").exists());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenSimulationDetailDoesNotExist() throws Exception {
+        String adminToken = loginAndGetToken("admin@finalspace.com", "admin123");
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/api/simulations/99999")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectSimulationDetailWithoutToken() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/api/simulations/1"))
+                .andExpect(status().isUnauthorized());
+    }
 }

--- a/backend/src/test/java/com/finalspace/backend/simulation/service/impl/SimulationHistoryServiceImplTest.java
+++ b/backend/src/test/java/com/finalspace/backend/simulation/service/impl/SimulationHistoryServiceImplTest.java
@@ -1,0 +1,195 @@
+package com.finalspace.backend.simulation.service.impl;
+
+import com.finalspace.backend.common.exception.ResourceNotFoundException;
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.mission.MissionStatus;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.satellite.SatelliteStatus;
+import com.finalspace.backend.simulation.SimulationRun;
+import com.finalspace.backend.simulation.SimulationRunRepository;
+import com.finalspace.backend.simulation.SimulationStatus;
+import com.finalspace.backend.simulation.SimulationType;
+import com.finalspace.backend.simulation.dto.SimulationDetailResponse;
+import com.finalspace.backend.simulation.dto.SimulationListItemResponse;
+import com.finalspace.backend.simulation.service.HohmannTransferService;
+import com.finalspace.backend.simulation.service.OrbitSimulationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SimulationHistoryServiceImplTest {
+
+    @Mock
+    private SatelliteRepository satelliteRepository;
+
+    @Mock
+    private SimulationRunRepository simulationRunRepository;
+
+    @Mock
+    private OrbitSimulationService orbitSimulationService;
+
+    @Mock
+    private HohmannTransferService hohmannTransferService;
+
+    @InjectMocks
+    private SimulationServiceImpl simulationService;
+
+    @Test
+    void shouldReturnSimulationHistoryForSatelliteOrderedByCreatedAtDesc() {
+        Satellite satellite = activeSatellite();
+
+        SimulationRun latestRun = hohmannRun(21L, satellite, LocalDateTime.now());
+        SimulationRun olderRun = orbitRun(20L, satellite, LocalDateTime.now().minusHours(1));
+
+        when(satelliteRepository.existsById(3L)).thenReturn(true);
+        when(simulationRunRepository.findBySatelliteIdOrderByCreatedAtDesc(3L))
+                .thenReturn(List.of(latestRun, olderRun));
+
+        List<SimulationListItemResponse> result = simulationService.findSimulationsBySatellite(3L);
+
+        assertThat(result).hasSize(2);
+
+        assertThat(result.get(0).id()).isEqualTo(21L);
+        assertThat(result.get(0).type()).isEqualTo(SimulationType.HOHMANN);
+        assertThat(result.get(0).targetAltitudeKm()).isEqualTo(800.0);
+        assertThat(result.get(0).deltaVTotalMS()).isEqualTo(161.0);
+        assertThat(result.get(0).transferTimeMinutes()).isEqualTo(48.79);
+
+        assertThat(result.get(1).id()).isEqualTo(20L);
+        assertThat(result.get(1).type()).isEqualTo(SimulationType.ORBIT);
+        assertThat(result.get(1).orbitalPeriodMinutes()).isEqualTo(94.47);
+        assertThat(result.get(1).averageVelocityKmS()).isEqualTo(7.62);
+        assertThat(result.get(1).orbitShape()).isEqualTo("ELLIPTIQUE");
+    }
+
+    @Test
+    void shouldReturnEmptySimulationHistoryForSatelliteWithoutRuns() {
+        when(satelliteRepository.existsById(3L)).thenReturn(true);
+        when(simulationRunRepository.findBySatelliteIdOrderByCreatedAtDesc(3L))
+                .thenReturn(List.of());
+
+        List<SimulationListItemResponse> result = simulationService.findSimulationsBySatellite(3L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldRejectHistoryWhenSatelliteDoesNotExist() {
+        when(satelliteRepository.existsById(99L)).thenReturn(false);
+
+        assertThatThrownBy(() -> simulationService.findSimulationsBySatellite(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Satellite introuvable");
+
+        verify(simulationRunRepository, never()).findBySatelliteIdOrderByCreatedAtDesc(99L);
+    }
+
+    @Test
+    void shouldReturnSimulationDetail() {
+        Satellite satellite = activeSatellite();
+        SimulationRun run = hohmannRun(21L, satellite, LocalDateTime.now());
+
+        when(simulationRunRepository.findById(21L)).thenReturn(Optional.of(run));
+
+        SimulationDetailResponse response = simulationService.findSimulationById(21L);
+
+        assertThat(response.id()).isEqualTo(21L);
+        assertThat(response.type()).isEqualTo(SimulationType.HOHMANN);
+        assertThat(response.status()).isEqualTo(SimulationStatus.SUCCESS);
+        assertThat(response.missionId()).isEqualTo(4L);
+        assertThat(response.satelliteId()).isEqualTo(3L);
+        assertThat(response.inputMassKg()).isEqualTo(850.0);
+        assertThat(response.inputAltitudeKm()).isEqualTo(500.0);
+        assertThat(response.targetAltitudeKm()).isEqualTo(800.0);
+        assertThat(response.deltaV1MS()).isEqualTo(80.93);
+        assertThat(response.deltaV2MS()).isEqualTo(80.07);
+        assertThat(response.deltaVTotalMS()).isEqualTo(161.0);
+        assertThat(response.transferTimeMinutes()).isEqualTo(48.79);
+        assertThat(response.plotDataJson()).contains("transferArc");
+    }
+
+    @Test
+    void shouldRejectDetailWhenSimulationDoesNotExist() {
+        when(simulationRunRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> simulationService.findSimulationById(999L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Simulation introuvable");
+    }
+
+    private Satellite activeSatellite() {
+        Mission mission = Mission.builder()
+                .id(4L)
+                .name("Mission to the MOOOOON")
+                .status(MissionStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return Satellite.builder()
+                .id(3L)
+                .name("LunaSat-03")
+                .status(SatelliteStatus.ACTIF)
+                .massKg(850.0)
+                .altitudeKm(500.0)
+                .inclinationDeg(95.0)
+                .eccentricity(0.4)
+                .mission(mission)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private SimulationRun orbitRun(Long id, Satellite satellite, LocalDateTime createdAt) {
+        return SimulationRun.builder()
+                .id(id)
+                .mission(satellite.getMission())
+                .satellite(satellite)
+                .type(SimulationType.ORBIT)
+                .status(SimulationStatus.SUCCESS)
+                .inputMassKg(850.0)
+                .inputAltitudeKm(500.0)
+                .inputInclinationDeg(95.0)
+                .inputEccentricity(0.4)
+                .orbitalPeriodMinutes(94.47)
+                .averageVelocityKmS(7.62)
+                .orbitShape("ELLIPTIQUE")
+                .plotDataJson("[{\"x\":1,\"y\":0}]")
+                .createdAt(createdAt)
+                .createdBy("admin@finalspace.com")
+                .build();
+    }
+
+    private SimulationRun hohmannRun(Long id, Satellite satellite, LocalDateTime createdAt) {
+        return SimulationRun.builder()
+                .id(id)
+                .mission(satellite.getMission())
+                .satellite(satellite)
+                .type(SimulationType.HOHMANN)
+                .status(SimulationStatus.SUCCESS)
+                .inputMassKg(850.0)
+                .inputAltitudeKm(500.0)
+                .inputInclinationDeg(95.0)
+                .inputEccentricity(0.4)
+                .targetAltitudeKm(800.0)
+                .deltaV1MS(80.93)
+                .deltaV2MS(80.07)
+                .deltaVTotalMS(161.0)
+                .transferTimeMinutes(48.79)
+                .plotDataJson("{\"initialOrbit\":[],\"targetOrbit\":[],\"transferArc\":[]}")
+                .createdAt(createdAt)
+                .createdBy("admin@finalspace.com")
+                .build();
+    }
+}

--- a/docs/tests/US14-tests.md
+++ b/docs/tests/US14-tests.md
@@ -1,0 +1,345 @@
+# US14 - Consulter l’historique des simulations
+
+## État de validation
+
+**US14 validée côté backend et frontend.**
+
+L’application permet de consulter l’historique des simulations associées à un satellite.
+
+L’utilisateur peut :
+
+- consulter la liste des simulations d’un satellite ;
+- identifier le type de simulation réalisée ;
+- visualiser les résultats synthétiques ;
+- accéder au détail complet d’une simulation ;
+- consulter les paramètres figés utilisés lors du lancement ;
+- consulter les résultats calculés ;
+- consulter une visualisation 2D simplifiée.
+
+---
+
+## Objectif de l’US
+
+Permettre à un utilisateur authentifié de consulter l’historique des simulations afin de retrouver, analyser et comparer les résultats des simulations effectuées sur un satellite.
+
+Les simulations concernées sont :
+
+- les simulations orbitales simples ;
+- les manœuvres de transfert de Hohmann.
+
+---
+
+## Dépendances
+
+| User Story | Description | État |
+|---|---|---|
+| US12 | Lancer une simulation d’orbite | Validée |
+| US13 | Lancer une manœuvre de transfert de Hohmann | Validée |
+
+L’US14 s’appuie sur les runs de simulation déjà persistés par les US12 et US13.
+
+---
+
+## Choix d’implémentation
+
+L’historique repose sur l’entité `SimulationRun`.
+
+Cette entité conserve les informations communes aux différents types de simulation :
+
+- mission associée ;
+- satellite associé ;
+- type de simulation ;
+- statut ;
+- paramètres figés ;
+- résultats calculés ;
+- données de visualisation ;
+- date de lancement ;
+- auteur.
+
+Le champ `type` permet de distinguer les simulations :
+
+```text
+ORBIT
+HOHMANN
+```
+
+Deux DTO ont été ajoutés pour séparer les besoins d’affichage :
+
+| DTO | Utilisation |
+|---|---|
+| `SimulationListItemResponse` | Affichage de la liste des simulations |
+| `SimulationDetailResponse` | Affichage du détail complet d’une simulation |
+
+Ce découpage évite de renvoyer les données techniques lourdes, notamment `plotDataJson`, dans la liste.
+
+---
+
+## Endpoints ajoutés
+
+| Méthode | Endpoint | Description | Rôles autorisés |
+|---|---|---|---|
+| `GET` | `/api/satellites/{id}/simulations` | Consulter l’historique des simulations d’un satellite | ADMIN, OPERATEUR, LECTEUR |
+| `GET` | `/api/simulations/{id}` | Consulter le détail complet d’une simulation | ADMIN, OPERATEUR, LECTEUR |
+
+---
+
+## Règles métier couvertes
+
+| Référence | Règle | État |
+|---|---|---|
+| RG-HIST-01 | Les simulations sont conservées sans limitation de durée | PASS |
+| RG-HIST-02 | Les simulations ne peuvent pas être modifiées | PASS |
+| RG-HIST-03 | Les simulations ne peuvent pas être supprimées | PASS |
+| RG-HIST-04 | Les simulations restent consultables même si la mission est clôturée | PASS |
+| RG-HIST-05 | Les simulations restent consultables même si le satellite est inactif | PASS |
+| RG-HIST-06 | L’historique est trié par date décroissante | PASS |
+| RG-HIST-07 | Le détail d’une simulation est consultable | PASS |
+| RG-HIST-08 | ADMIN peut consulter l’historique | PASS |
+| RG-HIST-09 | OPERATEUR peut consulter l’historique | PASS |
+| RG-HIST-10 | LECTEUR peut consulter l’historique | PASS |
+| RG-HIST-11 | Un utilisateur non authentifié est refusé | PASS |
+
+---
+
+## Données affichées dans la liste
+
+La liste des simulations affiche les informations suivantes :
+
+| Champ | Description | État |
+|---|---|---|
+| `id` | Identifiant de la simulation | PASS |
+| `missionId` | Identifiant de la mission associée | PASS |
+| `missionName` | Nom de la mission associée | PASS |
+| `satelliteId` | Identifiant du satellite associé | PASS |
+| `satelliteName` | Nom du satellite associé | PASS |
+| `type` | Type de simulation | PASS |
+| `status` | Statut de la simulation | PASS |
+| `createdAt` | Date de lancement | PASS |
+| `createdBy` | Auteur du lancement | PASS |
+| `inputAltitudeKm` | Altitude initiale utilisée | PASS |
+| `targetAltitudeKm` | Altitude cible pour Hohmann | PASS |
+| `orbitalPeriodMinutes` | Période orbitale pour ORBIT | PASS |
+| `averageVelocityKmS` | Vitesse moyenne pour ORBIT | PASS |
+| `orbitShape` | Forme de l’orbite pour ORBIT | PASS |
+| `deltaVTotalMS` | Δv total pour HOHMANN | PASS |
+| `transferTimeMinutes` | Durée du transfert pour HOHMANN | PASS |
+
+---
+
+## Données affichées dans le détail
+
+Le détail d’une simulation affiche les informations suivantes :
+
+| Champ | Description | État |
+|---|---|---|
+| `id` | Identifiant de la simulation | PASS |
+| `missionId` | Identifiant de la mission associée | PASS |
+| `missionName` | Nom de la mission associée | PASS |
+| `satelliteId` | Identifiant du satellite associé | PASS |
+| `satelliteName` | Nom du satellite associé | PASS |
+| `type` | Type de simulation | PASS |
+| `status` | Statut du run | PASS |
+| `inputMassKg` | Masse figée au lancement | PASS |
+| `inputAltitudeKm` | Altitude initiale figée | PASS |
+| `inputInclinationDeg` | Inclinaison figée | PASS |
+| `inputEccentricity` | Excentricité figée | PASS |
+| `orbitalPeriodMinutes` | Période orbitale | PASS |
+| `averageVelocityKmS` | Vitesse moyenne | PASS |
+| `orbitShape` | Forme de l’orbite | PASS |
+| `targetAltitudeKm` | Altitude cible Hohmann | PASS |
+| `deltaV1MS` | Δv départ | PASS |
+| `deltaV2MS` | Δv arrivée | PASS |
+| `deltaVTotalMS` | Δv total | PASS |
+| `transferTimeMinutes` | Durée estimée | PASS |
+| `plotDataJson` | Données de visualisation | PASS |
+| `createdAt` | Date de lancement | PASS |
+| `createdBy` | Auteur | PASS |
+
+---
+
+## Tests unitaires - SimulationHistoryServiceImplTest
+
+Classe associée :
+
+```text
+backend/src/test/java/com/finalspace/backend/simulation/service/impl/SimulationHistoryServiceImplTest.java
+```
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US14-T01 | Récupérer l’historique d’un satellite avec plusieurs simulations | Liste retournée avec les runs | PASS |
+| US14-T02 | Vérifier le tri par date décroissante | Simulation la plus récente en premier | PASS |
+| US14-T03 | Récupérer l’historique d’un satellite sans simulation | Liste vide retournée | PASS |
+| US14-T04 | Récupérer l’historique d’un satellite inexistant | Erreur `Satellite introuvable` | PASS |
+| US14-T05 | Récupérer le détail d’une simulation | Détail complet retourné | PASS |
+| US14-T06 | Récupérer une simulation inexistante | Erreur `Simulation introuvable` | PASS |
+
+---
+
+## Tests d’intégration API / sécurité
+
+Classe associée :
+
+```text
+backend/src/test/java/com/finalspace/backend/security/SimulationAuthorizationIntegrationTest.java
+```
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US14-T07 | ADMIN consulte l’historique d’un satellite | `200 OK` | PASS |
+| US14-T08 | LECTEUR consulte l’historique d’un satellite | `200 OK` | PASS |
+| US14-T09 | Historique demandé pour satellite inexistant | `404 Not Found` | PASS |
+| US14-T10 | Historique demandé sans token | `401 Unauthorized` | PASS |
+| US14-T11 | ADMIN consulte le détail d’une simulation | `200 OK` | PASS |
+| US14-T12 | LECTEUR consulte le détail d’une simulation | `200 OK` | PASS |
+| US14-T13 | Détail demandé pour simulation inexistante | `404 Not Found` | PASS |
+| US14-T14 | Détail demandé sans token | `401 Unauthorized` | PASS |
+
+---
+
+## Tests Postman réalisés
+
+| Scénario | Endpoint | Résultat attendu | État |
+|---|---|---|---|
+| Consulter l’historique d’un satellite | `GET /api/satellites/{id}/simulations` | Liste des simulations | PASS |
+| Consulter le détail d’une simulation Hohmann | `GET /api/simulations/{id}` | Détail complet | PASS |
+| Vérifier les champs Hohmann | `GET /api/simulations/{id}` | Δv, durée, altitude cible | PASS |
+| Vérifier les paramètres figés | `GET /api/simulations/{id}` | masse, altitude, inclinaison, excentricité | PASS |
+| Vérifier `plotDataJson` | `GET /api/simulations/{id}` | Données de visualisation présentes | PASS |
+
+---
+
+## Tests frontend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US14-T15 | Afficher l’historique sur la page détail satellite | Tableau visible | PASS |
+| US14-T16 | Afficher une simulation ORBIT dans le tableau | Type et résumé orbitaux visibles | PASS |
+| US14-T17 | Afficher une simulation HOHMANN dans le tableau | Type et résumé Hohmann visibles | PASS |
+| US14-T18 | Afficher les colonnes date, type, statut, auteur, résumé | Colonnes visibles | PASS |
+| US14-T19 | Cliquer sur `Voir détail` | Navigation vers `/simulations/{id}` | PASS |
+| US14-T20 | Afficher le détail d’une simulation | Page détail visible | PASS |
+| US14-T21 | Afficher les paramètres figés | Paramètres visibles | PASS |
+| US14-T22 | Afficher les résultats calculés | Résultats visibles | PASS |
+| US14-T23 | Afficher la visualisation 2D | Visualisation visible | PASS |
+| US14-T24 | Consulter l’historique avec le rôle LECTEUR | Accès autorisé | PASS |
+| US14-T25 | Consulter le détail avec le rôle LECTEUR | Accès autorisé | PASS |
+| US14-T26 | Historique vide | Message d’état vide affiché | PASS |
+| US14-T27 | Erreur de chargement | Message d’erreur affiché | PASS |
+| US14-T28 | Build Angular | Build OK | PASS |
+
+---
+
+## Résultat d’exécution automatisée
+
+Commande exécutée côté backend :
+
+```bash
+./mvnw clean test
+```
+
+Résultat :
+
+```text
+Tests run: 168, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+Commande exécutée côté frontend :
+
+```bash
+npm run build
+```
+
+Résultat :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+## Validation navigateur
+
+La fonctionnalité a été testée manuellement dans le navigateur.
+
+Cas validés :
+
+- l’historique des simulations apparaît sur la page détail satellite ;
+- les simulations sont affichées dans un tableau ;
+- les simulations sont bien distinguées par type ;
+- le résumé affiché dépend du type de simulation ;
+- le clic sur `Voir détail` ouvre la page détail ;
+- la page détail affiche les paramètres et les résultats ;
+- la page détail affiche une visualisation 2D ;
+- le rôle `LECTEUR` peut consulter l’historique ;
+- le rôle `LECTEUR` peut consulter le détail d’une simulation.
+
+---
+
+## Sécurité
+
+| Rôle | Historique satellite | Détail simulation |
+|---|---|---|
+| ADMIN | Autorisé | Autorisé |
+| OPERATEUR | Autorisé | Autorisé |
+| LECTEUR | Autorisé | Autorisé |
+| Non authentifié | Refusé | Refusé |
+
+---
+
+## Hors périmètre
+
+Les éléments suivants ne sont pas couverts par l’US14 :
+
+- suppression des simulations ;
+- modification des simulations ;
+- comparaison avancée entre plusieurs simulations ;
+- rejeu d’une simulation existante ;
+- duplication d’une simulation existante ;
+- export CSV/PDF ;
+- pagination ;
+- filtrage avancé ;
+- historique global par mission côté interface.
+
+---
+
+## Limites actuelles
+
+La fonctionnalité actuelle ne propose pas encore :
+
+- de pagination ;
+- de filtre par type de simulation ;
+- de recherche dans l’historique ;
+- de comparaison graphique ;
+- d’export des résultats ;
+- de page historique mission dédiée.
+
+---
+
+## Perspectives d’évolution
+
+Évolutions possibles :
+
+- ajouter un historique des simulations au niveau mission ;
+- ajouter une pagination côté backend et frontend ;
+- ajouter des filtres par type de simulation ;
+- ajouter une comparaison entre simulations ;
+- ajouter l’export CSV/PDF ;
+- améliorer la visualisation 2D ;
+- ajouter une visualisation 3D simplifiée ;
+- ajouter des graphiques comparatifs entre plusieurs runs.
+
+---
+
+## Conclusion
+
+L’US14 est terminée.
+
+L’application permet désormais de consulter l’historique des simulations d’un satellite et d’accéder au détail complet d’une simulation.
+
+Les simulations orbitales et les manœuvres de Hohmann sont historisées, consultables et affichées côté frontend.
+
+Les droits d’accès sont respectés pour les rôles ADMIN, OPERATEUR et LECTEUR.
+
+Les tests backend passent avec succès et le build frontend est validé.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import { MissionDashboardPageComponent } from './mission-dashboard/mission-dashb
 import { MissionAlertListComponent } from './alerts/mission-alert-list/mission-alert-list.component';
 import { MissionIncidentListComponent } from './incidents/mission-incident-list/mission-incident-list.component';
 import { SatelliteDetailComponent } from './satellites/satellite-detail/satellite-detail.component';
+import { SimulationDetailComponent } from './simulations/simulation-detail/simulation-detail.component';
 
 export const routes: Routes = [
   {
@@ -54,6 +55,11 @@ export const routes: Routes = [
     path: 'satellites/:id',
     canActivate: [authGuard],
     component: SatelliteDetailComponent
+  },
+  {
+    path: 'simulations/:id',
+    canActivate: [authGuard],
+    component: SimulationDetailComponent
   },
   {
     path: 'forbidden',

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.css
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.css
@@ -377,3 +377,98 @@ input:focus {
   stroke: #f59e0b;
   stroke-width: 3;
 }
+
+.simulation-history-section {
+  margin-top: 32px;
+  padding: 24px;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.history-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  margin-top: 18px;
+  border: 1px solid #334155;
+  border-radius: 14px;
+}
+
+.history-table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+  background: rgba(2, 6, 23, 0.65);
+}
+
+.history-table th,
+.history-table td {
+  padding: 14px 16px;
+  text-align: left;
+  border-bottom: 1px solid #334155;
+  vertical-align: middle;
+}
+
+.history-table th {
+  color: #cbd5e1;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(15, 23, 42, 0.95);
+}
+
+.history-table td {
+  color: #e2e8f0;
+  font-size: 14px;
+}
+
+.history-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.history-table tbody tr:hover {
+  background: rgba(30, 41, 59, 0.7);
+}
+
+.simulation-type-badge,
+.simulation-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.simulation-type-badge {
+  color: #bae6fd;
+  background: rgba(2, 132, 199, 0.22);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+}
+
+.simulation-status-badge.success {
+  color: #bbf7d0;
+  background: rgba(22, 163, 74, 0.22);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.simulation-status-badge.failed {
+  color: #fecaca;
+  background: rgba(220, 38, 38, 0.22);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.secondary-link {
+  color: #93c5fd;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.secondary-link:hover {
+  color: #bfdbfe;
+  text-decoration: underline;
+}

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.html
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.html
@@ -488,10 +488,90 @@
             <circle cx="270" cy="160" r="4" class="satellite-marker"></circle>
           </svg>
         </div>
+      </div>
+    </section>
+    <section class="simulation-history-section">
+      <div class="simulation-header">
+        <div>
+          <h2>Historique des simulations</h2>
+          <p>
+            Consulte les simulations orbitales et les manœuvres de Hohmann déjà lancées pour ce satellite.
+          </p>
+        </div>
+      </div>
 
-        <p class="orbit-note">
-          Visualisation schématique : l’orbite initiale, l’orbite cible et l’arc de transfert sont représentés de manière simplifiée.
-        </p>
+      <div *ngIf="simulationHistoryLoading" class="info-card">
+        Chargement de l’historique des simulations...
+      </div>
+
+      <div *ngIf="simulationHistoryErrorMessage" class="error-card">
+        {{ simulationHistoryErrorMessage }}
+      </div>
+
+      <div
+        *ngIf="!simulationHistoryLoading && !simulationHistoryErrorMessage && simulationHistory.length === 0"
+        class="info-card"
+      >
+        Aucune simulation n’a encore été lancée pour ce satellite.
+      </div>
+
+      <div
+        *ngIf="!simulationHistoryLoading && simulationHistory.length > 0"
+        class="history-table-wrapper"
+      >
+        <table class="history-table">
+          <thead>
+          <tr>
+            <th>Date</th>
+            <th>Type</th>
+            <th>Statut</th>
+            <th>Auteur</th>
+            <th>Résumé</th>
+            <th>Action</th>
+          </tr>
+          </thead>
+
+          <tbody>
+          <tr *ngFor="let simulation of simulationHistory">
+            <td>
+              {{ simulation.createdAt | date:'dd/MM/yyyy HH:mm' }}
+            </td>
+
+            <td>
+            <span class="simulation-type-badge">
+              {{ getSimulationTypeLabel(simulation.type) }}
+            </span>
+            </td>
+
+            <td>
+            <span
+              class="simulation-status-badge"
+              [class.success]="simulation.status === 'SUCCESS'"
+              [class.failed]="simulation.status === 'FAILED'"
+            >
+              {{ simulation.status }}
+            </span>
+            </td>
+
+            <td>
+              {{ simulation.createdBy }}
+            </td>
+
+            <td>
+              {{ getSimulationSummary(simulation) }}
+            </td>
+
+            <td>
+              <a
+                class="secondary-link"
+                [routerLink]="['/simulations', simulation.id]"
+              >
+                Voir détail
+              </a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
       </div>
     </section>
   </div>

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.ts
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.ts
@@ -5,8 +5,13 @@ import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../auth/auth.service';
 import { Satellite, SatelliteUpdateRequest } from '../models/satellite.model';
 import { SatelliteService } from '../services/satellite.service';
-import { HohmannPlotData, SimulationResponse, OrbitPlotPoint } from '../../simulations/models/simulation.model';
 import { SimulationService } from '../../simulations/services/simulation.service';
+import {
+  HohmannPlotData,
+  SimulationListItemResponse,
+  SimulationResponse,
+  OrbitPlotPoint
+} from '../../simulations/models/simulation.model';
 
 @Component({
   selector: 'app-satellite-detail',
@@ -42,6 +47,9 @@ export class SatelliteDetailComponent implements OnInit {
   hohmannResult: SimulationResponse | null = null;
   hohmannErrorMessage = '';
   hohmannPlotData: HohmannPlotData | null = null;
+  simulationHistory: SimulationListItemResponse[] = [];
+  simulationHistoryLoading = false;
+  simulationHistoryErrorMessage = '';
 
   constructor(
     private route: ActivatedRoute,
@@ -76,6 +84,7 @@ export class SatelliteDetailComponent implements OnInit {
         this.editInclinationDeg = satellite.inclinationDeg ?? null;
         this.editEccentricity = satellite.eccentricity ?? null;
         this.loading = false;
+        this.loadSimulationHistory(satellite.id);
       },
       error: (error) => {
         this.loading = false;
@@ -91,6 +100,33 @@ export class SatelliteDetailComponent implements OnInit {
         }
 
         this.errorMessage = 'Impossible de charger le satellite.';
+      }
+    });
+  }
+
+  loadSimulationHistory(satelliteId: number): void {
+    this.simulationHistoryLoading = true;
+    this.simulationHistoryErrorMessage = '';
+
+    this.simulationService.findBySatellite(satelliteId).subscribe({
+      next: (history) => {
+        this.simulationHistory = history;
+        this.simulationHistoryLoading = false;
+      },
+      error: (error) => {
+        this.simulationHistoryLoading = false;
+
+        if (error.status === 403) {
+          this.router.navigate(['/forbidden']);
+          return;
+        }
+
+        if (error.status === 404) {
+          this.simulationHistoryErrorMessage = 'Historique introuvable pour ce satellite.';
+          return;
+        }
+
+        this.simulationHistoryErrorMessage = 'Impossible de charger l’historique des simulations.';
       }
     });
   }
@@ -249,6 +285,7 @@ export class SatelliteDetailComponent implements OnInit {
         this.simulationResult = simulation;
         this.orbitPlotPoints = this.parsePlotData(simulation.plotDataJson);
         this.successMessage = 'Simulation orbitale lancée avec succès.';
+        this.loadSimulationHistory(simulation.satelliteId);
       },
       error: (error) => {
         this.simulationLaunching = false;
@@ -377,6 +414,7 @@ export class SatelliteDetailComponent implements OnInit {
           this.hohmannResult = result;
           this.hohmannPlotData = this.parseHohmannPlotData(result.plotDataJson);
           this.hohmannLaunching = false;
+          this.loadSimulationHistory(result.satelliteId);
         },
         error: () => {
           this.hohmannErrorMessage = 'Impossible de lancer la manœuvre de Hohmann.';
@@ -428,5 +466,30 @@ export class SatelliteDetailComponent implements OnInit {
 
   showHohmannSection(): boolean {
     return this.canLaunchOrbitSimulation() || this.hohmannResult !== null;
+  }
+
+  getSimulationSummary(simulation: SimulationListItemResponse): string {
+    if (simulation.type === 'HOHMANN') {
+      const deltaV = simulation.deltaVTotalMS ?? '-';
+      const duration = simulation.transferTimeMinutes ?? '-';
+      return `Δv total : ${deltaV} m/s · Durée : ${duration} min`;
+    }
+
+    const period = simulation.orbitalPeriodMinutes ?? '-';
+    const velocity = simulation.averageVelocityKmS ?? '-';
+    const shape = simulation.orbitShape ?? '-';
+    return `Période : ${period} min · Vitesse : ${velocity} km/s · Forme : ${shape}`;
+  }
+
+  getSimulationTypeLabel(type: string): string {
+    if (type === 'HOHMANN') {
+      return 'Hohmann';
+    }
+
+    if (type === 'ORBIT') {
+      return 'Orbite';
+    }
+
+    return type;
   }
 }

--- a/frontend/src/app/simulations/models/simulation.model.ts
+++ b/frontend/src/app/simulations/models/simulation.model.ts
@@ -42,3 +42,25 @@ export interface HohmannPlotData {
   targetOrbit: OrbitPlotPoint[];
   transferArc: OrbitPlotPoint[];
 }
+
+export interface SimulationListItemResponse {
+  id: number;
+  missionId: number;
+  missionName: string;
+  satelliteId: number;
+  satelliteName: string;
+  type: SimulationType;
+  status: SimulationStatus;
+  createdAt: string;
+  createdBy: string;
+
+  inputAltitudeKm: number | null;
+  targetAltitudeKm: number | null;
+
+  orbitalPeriodMinutes: number | null;
+  averageVelocityKmS: number | null;
+  orbitShape: string | null;
+
+  deltaVTotalMS: number | null;
+  transferTimeMinutes: number | null;
+}

--- a/frontend/src/app/simulations/services/simulation.service.ts
+++ b/frontend/src/app/simulations/services/simulation.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { SimulationResponse } from '../models/simulation.model';
+import { SimulationResponse, SimulationListItemResponse } from '../models/simulation.model';
 
 @Injectable({
   providedIn: 'root'
@@ -26,6 +26,18 @@ export class SimulationService {
     return this.http.post<SimulationResponse>(
       `${this.apiUrl}/satellites/${satelliteId}/simulations/hohmann`,
       { altitudeTargetKm }
+    );
+  }
+
+  findBySatellite(satelliteId: number): Observable<SimulationListItemResponse[]> {
+    return this.http.get<SimulationListItemResponse[]>(
+      `${this.apiUrl}/satellites/${satelliteId}/simulations`
+    );
+  }
+
+  findById(simulationId: number): Observable<SimulationResponse> {
+    return this.http.get<SimulationResponse>(
+      `${this.apiUrl}/simulations/${simulationId}`
     );
   }
 }

--- a/frontend/src/app/simulations/simulation-detail/simulation-detail.component.css
+++ b/frontend/src/app/simulations/simulation-detail/simulation-detail.component.css
@@ -1,0 +1,239 @@
+.page-container {
+  min-height: 100vh;
+  padding: 32px;
+  color: #e2e8f0;
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 32%),
+    radial-gradient(circle at top right, rgba(245, 158, 11, 0.1), transparent 28%),
+    #020617;
+}
+
+.back-button {
+  margin-bottom: 20px;
+  padding: 10px 16px;
+  border: 1px solid #334155;
+  border-radius: 999px;
+  color: #cbd5e1;
+  background: rgba(15, 23, 42, 0.8);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.back-button:hover {
+  color: #f8fafc;
+  border-color: #38bdf8;
+  background: rgba(30, 41, 59, 0.9);
+}
+
+.info-card,
+.error-card {
+  padding: 16px 18px;
+  border-radius: 14px;
+  margin-bottom: 18px;
+  font-weight: 600;
+}
+
+.info-card {
+  color: #bae6fd;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(2, 132, 199, 0.16);
+}
+
+.error-card {
+  color: #fecaca;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(127, 29, 29, 0.22);
+}
+
+.detail-card {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 28px;
+  border: 1px solid #334155;
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-start;
+  padding-bottom: 24px;
+  border-bottom: 1px solid #334155;
+}
+
+.detail-header h1 {
+  margin: 4px 0 10px;
+  color: #f8fafc;
+  font-size: 32px;
+}
+
+.detail-header p {
+  margin: 0;
+  color: #cbd5e1;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #38bdf8;
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 13px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.status-badge.success {
+  color: #bbf7d0;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: rgba(22, 163, 74, 0.22);
+}
+
+.status-badge.failed {
+  color: #fecaca;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(220, 38, 38, 0.22);
+}
+
+.section-block {
+  margin-top: 28px;
+  padding: 22px;
+  border: 1px solid #334155;
+  border-radius: 18px;
+  background: rgba(2, 6, 23, 0.48);
+}
+
+.section-block h2 {
+  margin: 0 0 18px;
+  color: #f8fafc;
+  font-size: 22px;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 14px;
+}
+
+.info-grid div {
+  padding: 14px;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.info-grid span {
+  display: block;
+  margin-bottom: 6px;
+  color: #94a3b8;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.info-grid strong {
+  color: #f8fafc;
+  font-size: 15px;
+}
+
+.visualization-card {
+  width: min(520px, 100%);
+  aspect-ratio: 1;
+  margin: 22px auto 0;
+  border: 1px solid #334155;
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at center, rgba(15, 23, 42, 0.2), transparent 45%),
+    rgba(2, 6, 23, 0.84);
+  overflow: hidden;
+}
+
+.orbit-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.orbit-path {
+  fill: none;
+  stroke: #38bdf8;
+  stroke-width: 2;
+  stroke-dasharray: 5 5;
+}
+
+.earth-body {
+  filter: drop-shadow(0 0 12px rgba(56, 189, 248, 0.45));
+}
+
+.satellite-marker {
+  fill: #f59e0b;
+  stroke: #fef3c7;
+  stroke-width: 1.5;
+}
+
+.hohmann-initial-orbit,
+.hohmann-target-orbit,
+.hohmann-transfer-arc {
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.hohmann-initial-orbit {
+  stroke: #38bdf8;
+  stroke-dasharray: 5 5;
+}
+
+.hohmann-target-orbit {
+  stroke: #22c55e;
+  stroke-dasharray: 5 5;
+}
+
+.hohmann-transfer-arc {
+  stroke: #f59e0b;
+  stroke-width: 3;
+}
+
+.json-block {
+  max-height: 320px;
+  overflow: auto;
+  padding: 16px;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  color: #cbd5e1;
+  background: rgba(2, 6, 23, 0.9);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (max-width: 720px) {
+  .page-container {
+    padding: 18px;
+  }
+
+  .detail-card {
+    padding: 18px;
+  }
+
+  .detail-header {
+    flex-direction: column;
+  }
+
+  .detail-header h1 {
+    font-size: 26px;
+  }
+}

--- a/frontend/src/app/simulations/simulation-detail/simulation-detail.component.html
+++ b/frontend/src/app/simulations/simulation-detail/simulation-detail.component.html
@@ -1,0 +1,201 @@
+<section class="page-container">
+  <button type="button" class="back-button" (click)="goBack()">
+    ← Retour
+  </button>
+
+  <div *ngIf="loading" class="info-card">
+    Chargement du détail de la simulation...
+  </div>
+
+  <div *ngIf="errorMessage" class="error-card">
+    {{ errorMessage }}
+  </div>
+
+  <article *ngIf="simulation && !loading" class="detail-card">
+    <header class="detail-header">
+      <div>
+        <p class="eyebrow">Simulation #{{ simulation.id }}</p>
+        <h1>{{ getSimulationTypeLabel() }}</h1>
+        <p>
+          Simulation lancée le
+          <strong>{{ simulation.createdAt | date:'dd/MM/yyyy HH:mm' }}</strong>
+          par
+          <strong>{{ simulation.createdBy }}</strong>.
+        </p>
+      </div>
+
+      <span
+        class="status-badge"
+        [class.success]="simulation.status === 'SUCCESS'"
+        [class.failed]="simulation.status === 'FAILED'"
+      >
+        {{ simulation.status }}
+      </span>
+    </header>
+
+    <section class="section-block">
+      <h2>Contexte</h2>
+
+      <div class="info-grid">
+        <div>
+          <span>Mission</span>
+          <strong>{{ simulation.missionName }}</strong>
+        </div>
+
+        <div>
+          <span>Satellite</span>
+          <strong>{{ simulation.satelliteName }}</strong>
+        </div>
+
+        <div>
+          <span>Type</span>
+          <strong>{{ simulation.type }}</strong>
+        </div>
+
+        <div>
+          <span>Auteur</span>
+          <strong>{{ simulation.createdBy }}</strong>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-block">
+      <h2>Paramètres utilisés</h2>
+
+      <div class="info-grid">
+        <div>
+          <span>Masse</span>
+          <strong>{{ simulation.inputMassKg }} kg</strong>
+        </div>
+
+        <div>
+          <span>Altitude initiale</span>
+          <strong>{{ simulation.inputAltitudeKm }} km</strong>
+        </div>
+
+        <div>
+          <span>Inclinaison</span>
+          <strong>{{ simulation.inputInclinationDeg }}°</strong>
+        </div>
+
+        <div>
+          <span>Excentricité</span>
+          <strong>{{ simulation.inputEccentricity }}</strong>
+        </div>
+
+        <div *ngIf="simulation.type === 'HOHMANN'">
+          <span>Altitude cible</span>
+          <strong>{{ simulation.targetAltitudeKm }} km</strong>
+        </div>
+      </div>
+    </section>
+
+    <section *ngIf="simulation.type === 'ORBIT'" class="section-block">
+      <h2>Résultats orbitaux</h2>
+
+      <div class="info-grid">
+        <div>
+          <span>Période orbitale</span>
+          <strong>{{ simulation.orbitalPeriodMinutes }} min</strong>
+        </div>
+
+        <div>
+          <span>Vitesse moyenne</span>
+          <strong>{{ simulation.averageVelocityKmS }} km/s</strong>
+        </div>
+
+        <div>
+          <span>Forme de l’orbite</span>
+          <strong>{{ simulation.orbitShape }}</strong>
+        </div>
+      </div>
+
+      <div class="visualization-card">
+        <svg viewBox="0 0 320 320" class="orbit-svg" role="img" aria-label="Visualisation orbitale">
+          <defs>
+            <radialGradient id="earthGradientDetailOrbit" cx="35%" cy="35%" r="70%">
+              <stop offset="0%" stop-color="#7dd3fc"></stop>
+              <stop offset="45%" stop-color="#0284c7"></stop>
+              <stop offset="100%" stop-color="#0f172a"></stop>
+            </radialGradient>
+          </defs>
+
+          <ellipse
+            [attr.cx]="getOrbitEllipse().cx"
+            [attr.cy]="getOrbitEllipse().cy"
+            [attr.rx]="getOrbitEllipse().rx"
+            [attr.ry]="getOrbitEllipse().ry"
+            class="orbit-path"
+          ></ellipse>
+
+          <circle
+            cx="160"
+            cy="160"
+            [attr.r]="getEarthRadius()"
+            class="earth-body"
+            fill="url(#earthGradientDetailOrbit)"
+          ></circle>
+
+          <circle
+            [attr.cx]="getSatelliteMarker().cx"
+            [attr.cy]="getSatelliteMarker().cy"
+            r="4"
+            class="satellite-marker"
+          ></circle>
+        </svg>
+      </div>
+    </section>
+
+    <section *ngIf="simulation.type === 'HOHMANN'" class="section-block">
+      <h2>Résultats Hohmann</h2>
+
+      <div class="info-grid">
+        <div>
+          <span>Δv départ</span>
+          <strong>{{ simulation.deltaV1MS }} m/s</strong>
+        </div>
+
+        <div>
+          <span>Δv arrivée</span>
+          <strong>{{ simulation.deltaV2MS }} m/s</strong>
+        </div>
+
+        <div>
+          <span>Δv total</span>
+          <strong>{{ simulation.deltaVTotalMS }} m/s</strong>
+        </div>
+
+        <div>
+          <span>Durée estimée</span>
+          <strong>{{ simulation.transferTimeMinutes }} min</strong>
+        </div>
+      </div>
+
+      <div *ngIf="hohmannPlotData" class="visualization-card">
+        <svg viewBox="0 0 320 320" class="orbit-svg" role="img" aria-label="Visualisation du transfert de Hohmann">
+          <defs>
+            <radialGradient id="earthGradientDetailHohmann" cx="35%" cy="35%" r="70%">
+              <stop offset="0%" stop-color="#7dd3fc"></stop>
+              <stop offset="45%" stop-color="#0284c7"></stop>
+              <stop offset="100%" stop-color="#0f172a"></stop>
+            </radialGradient>
+          </defs>
+
+          <circle cx="160" cy="160" r="18" class="earth-body" fill="url(#earthGradientDetailHohmann)"></circle>
+
+          <path [attr.d]="getHohmannPath(hohmannPlotData.initialOrbit)" class="hohmann-initial-orbit"></path>
+          <path [attr.d]="getHohmannPath(hohmannPlotData.targetOrbit)" class="hohmann-target-orbit"></path>
+          <path [attr.d]="getHohmannPath(hohmannPlotData.transferArc)" class="hohmann-transfer-arc"></path>
+
+          <circle cx="270" cy="160" r="4" class="satellite-marker"></circle>
+        </svg>
+      </div>
+    </section>
+
+    <section class="section-block">
+      <h2>Données techniques</h2>
+
+      <pre class="json-block">{{ simulation.plotDataJson }}</pre>
+    </section>
+  </article>
+</section>

--- a/frontend/src/app/simulations/simulation-detail/simulation-detail.component.ts
+++ b/frontend/src/app/simulations/simulation-detail/simulation-detail.component.ts
@@ -1,0 +1,207 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule, Location } from '@angular/common';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import {
+  HohmannPlotData,
+  OrbitPlotPoint,
+  SimulationResponse
+} from '../models/simulation.model';
+import { SimulationService } from '../services/simulation.service';
+
+@Component({
+  selector: 'app-simulation-detail',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './simulation-detail.component.html',
+  styleUrl: './simulation-detail.component.css'
+})
+export class SimulationDetailComponent implements OnInit {
+
+  simulation: SimulationResponse | null = null;
+
+  loading = false;
+  errorMessage = '';
+
+  orbitPlotPoints: OrbitPlotPoint[] = [];
+  hohmannPlotData: HohmannPlotData | null = null;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private location: Location,
+    private simulationService: SimulationService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadSimulation();
+  }
+
+  loadSimulation(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+
+    if (!id) {
+      this.errorMessage = 'Identifiant de simulation invalide.';
+      return;
+    }
+
+    this.loading = true;
+    this.errorMessage = '';
+
+    this.simulationService.findById(id).subscribe({
+      next: (simulation) => {
+        this.simulation = simulation;
+        this.loading = false;
+
+        if (simulation.type === 'ORBIT') {
+          this.orbitPlotPoints = this.parseOrbitPlotData(simulation.plotDataJson);
+          this.hohmannPlotData = null;
+        }
+
+        if (simulation.type === 'HOHMANN') {
+          this.hohmannPlotData = this.parseHohmannPlotData(simulation.plotDataJson);
+          this.orbitPlotPoints = [];
+        }
+      },
+      error: (error) => {
+        this.loading = false;
+
+        if (error.status === 403) {
+          this.router.navigate(['/forbidden']);
+          return;
+        }
+
+        if (error.status === 404) {
+          this.errorMessage = 'Simulation introuvable.';
+          return;
+        }
+
+        this.errorMessage = 'Impossible de charger le détail de la simulation.';
+      }
+    });
+  }
+
+  goBack(): void {
+    this.location.back();
+  }
+
+  getSimulationTypeLabel(): string {
+    if (!this.simulation) {
+      return '-';
+    }
+
+    if (this.simulation.type === 'HOHMANN') {
+      return 'Transfert de Hohmann';
+    }
+
+    if (this.simulation.type === 'ORBIT') {
+      return 'Simulation orbitale';
+    }
+
+    return this.simulation.type;
+  }
+
+  private parseOrbitPlotData(plotDataJson: string): OrbitPlotPoint[] {
+    try {
+      const parsed = JSON.parse(plotDataJson);
+
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed
+        .filter((point) => typeof point.x === 'number' && typeof point.y === 'number')
+        .map((point) => ({
+          x: point.x,
+          y: point.y
+        }));
+    } catch {
+      return [];
+    }
+  }
+
+  private parseHohmannPlotData(plotDataJson: string): HohmannPlotData | null {
+    try {
+      const parsed = JSON.parse(plotDataJson) as HohmannPlotData;
+
+      if (
+        !Array.isArray(parsed.initialOrbit) ||
+        !Array.isArray(parsed.targetOrbit) ||
+        !Array.isArray(parsed.transferArc)
+      ) {
+        return null;
+      }
+
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  getOrbitEllipse(): {
+    cx: number;
+    cy: number;
+    rx: number;
+    ry: number;
+  } {
+    const eccentricity = this.simulation?.inputEccentricity ?? 0;
+
+    const cx = 160;
+    const cy = 160;
+    const maxRadius = 115;
+    const safeEccentricity = Math.min(Math.max(eccentricity, 0), 0.85);
+
+    return {
+      cx,
+      cy,
+      rx: maxRadius,
+      ry: maxRadius * Math.sqrt(1 - safeEccentricity * safeEccentricity)
+    };
+  }
+
+  getEarthRadius(): number {
+    const altitude = this.simulation?.inputAltitudeKm ?? 400;
+
+    const minRadius = 8;
+    const maxRadius = 26;
+    const referenceAltitude = 400;
+
+    const rawRadius = 20 * (referenceAltitude / altitude);
+
+    return Math.max(minRadius, Math.min(maxRadius, rawRadius));
+  }
+
+  getSatelliteMarker(): {
+    cx: number;
+    cy: number;
+  } {
+    const ellipse = this.getOrbitEllipse();
+
+    return {
+      cx: ellipse.cx + ellipse.rx,
+      cy: ellipse.cy
+    };
+  }
+
+  getHohmannPath(points: OrbitPlotPoint[] | undefined): string {
+    if (!points || points.length === 0) {
+      return '';
+    }
+
+    return points
+      .map((point, index) => {
+        const normalized = this.normalizeHohmannPoint(point);
+        return `${index === 0 ? 'M' : 'L'} ${normalized.x} ${normalized.y}`;
+      })
+      .join(' ');
+  }
+
+  private normalizeHohmannPoint(point: OrbitPlotPoint): { x: number; y: number } {
+    const center = 160;
+    const scale = 110;
+
+    return {
+      x: center + point.x * scale,
+      y: center - point.y * scale
+    };
+  }
+}


### PR DESCRIPTION
## Résumé

- Ajout de l’historique des simulations par satellite
- Ajout du détail complet d’une simulation
- Ajout des endpoints :
  - `GET /api/satellites/{id}/simulations`
  - `GET /api/simulations/{id}`
- Ajout des DTO :
  - `SimulationListItemResponse`
  - `SimulationDetailResponse`
- Ajout de la section historique sur la page détail satellite
- Ajout de la page `/simulations/:id`
- Accès autorisé en consultation pour ADMIN, OPERATEUR et LECTEUR
- Mise à jour README
- Ajout de `docs/tests/US14-tests.md`

## Tests

- Backend : `./mvnw clean test` → 168 tests PASS
- Frontend : `npm run build` OK
- Test navigateur : tableau historique OK
- Test navigateur : page détail simulation OK
- Test navigateur : accès LECTEUR OK