### PR TITLE
feat(telemetry): add CSV import with MongoDB storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ jobs:
     name: Backend - Build
     runs-on: ubuntu-latest
 
+    services:
+      mongodb:
+        image: mongo:7
+        env:
+          MONGO_INITDB_ROOT_USERNAME: finalspace
+          MONGO_INITDB_ROOT_PASSWORD: finalspace
+          MONGO_INITDB_DATABASE: finalspace_test
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --username finalspace --password finalspace --authenticationDatabase admin --eval 'db.adminCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     defaults:
       run:
         working-directory: backend

--- a/README.md
+++ b/README.md
@@ -1333,6 +1333,282 @@ Ces points sont prévus hors périmètre de l’US14 ou dans des user stories fu
 
 ---
 
+## Import de données de télémétrie CSV
+
+L’application permet d’importer des données de télémétrie au format CSV pour un satellite actif.
+
+Les données de télémétrie représentent des mesures temporelles associées à un satellite et à une mission. Elles seront utilisées ensuite pour la visualisation, l’analyse et la détection d’anomalies.
+
+Cette fonctionnalité introduit l’utilisation d’une base de données non relationnelle dans le projet.
+
+---
+
+### Stockage NoSQL avec MongoDB
+
+Les données métier principales restent stockées dans PostgreSQL :
+
+- utilisateurs ;
+- missions ;
+- satellites ;
+- simulations ;
+- alertes ;
+- incidents.
+
+Les données de télémétrie sont stockées dans MongoDB, dans une collection dédiée :
+
+```text
+telemetry_points
+```
+
+Ce choix permet de séparer les données relationnelles classiques des données temporelles potentiellement volumineuses.
+
+MongoDB est utilisé pour stocker des documents de télémétrie de manière flexible.
+
+---
+
+### Document MongoDB
+
+Chaque point de télémétrie est stocké sous forme de document MongoDB.
+
+Structure d’un document :
+
+```json
+{
+  "id": "...",
+  "missionId": 4,
+  "satelliteId": 3,
+  "timestamp": "2026-01-01T10:00:00Z",
+  "metric": "temperature",
+  "value": 42.5,
+  "sourceImportId": "uuid",
+  "createdAt": "2026-06-21T11:28:30Z"
+}
+```
+
+Un index composé est ajouté sur :
+
+```text
+satelliteId, metric, timestamp
+```
+
+Cet index prépare les usages futurs de visualisation par satellite, métrique et période temporelle.
+
+---
+
+### Format CSV attendu
+
+Le fichier CSV doit contenir un header obligatoire avec les colonnes suivantes :
+
+```csv
+timestamp,metric,value
+```
+
+Exemple de fichier valide :
+
+```csv
+timestamp,metric,value
+2026-01-01T10:00:00Z,temperature,42.5
+2026-01-01T10:00:00Z,battery,78
+```
+
+Les règles de validation sont les suivantes :
+
+| Colonne | Règle |
+|---|---|
+| `timestamp` | Date au format ISO-8601 |
+| `metric` | Nom de métrique non vide |
+| `value` | Valeur numérique |
+
+Le séparateur attendu est la virgule.
+
+---
+
+### Endpoint API
+
+| Méthode | Endpoint | Description | Rôles autorisés |
+|---|---|---|---|
+| `POST` | `/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import` | Importer un fichier CSV de télémétrie | ADMIN, OPERATEUR |
+
+Le rôle `LECTEUR` ne peut pas importer de données de télémétrie.
+
+---
+
+### Exemple de requête
+
+```http
+POST /api/missions/4/satellites/3/telemetry/import
+Authorization: Bearer <token>
+Content-Type: multipart/form-data
+```
+
+Body :
+
+```text
+file = telemetry-valid.csv
+```
+
+Réponse en cas de succès :
+
+```json
+{
+  "importId": "a8c9129a-2002-491a-a61a-7ddf4fe3373c",
+  "importedCount": 2,
+  "errorCount": 0,
+  "errors": []
+}
+```
+
+---
+
+### Gestion des erreurs CSV
+
+Si le fichier CSV est invalide, l’import est refusé.
+
+Aucune donnée partielle n’est conservée.
+
+Exemple de réponse en erreur :
+
+```json
+{
+  "importId": null,
+  "importedCount": 0,
+  "errorCount": 3,
+  "errors": [
+    {
+      "line": 3,
+      "message": "Timestamp invalide. Format attendu : ISO-8601, exemple 2026-01-01T10:00:00Z"
+    },
+    {
+      "line": 4,
+      "message": "La métrique est obligatoire"
+    },
+    {
+      "line": 5,
+      "message": "La valeur doit être numérique"
+    }
+  ]
+}
+```
+
+---
+
+### Règles métier
+
+| Règle | Description |
+|---|---|
+| Satellite actif | L’import est autorisé uniquement sur un satellite `ACTIF` |
+| Mission active | L’import est refusé si la mission est clôturée |
+| Satellite rattaché à la mission | Le satellite doit appartenir à la mission indiquée |
+| Format CSV obligatoire | Le fichier doit être au format `.csv` |
+| Header obligatoire | Le header doit être exactement `timestamp,metric,value` |
+| Timestamp valide | Le timestamp doit être parsable au format ISO-8601 |
+| Métrique obligatoire | Le champ `metric` ne doit pas être vide |
+| Valeur numérique | Le champ `value` doit être numérique |
+| Aucune donnée partielle | Si une ligne est invalide, aucune ligne n’est persistée |
+| Sécurité | ADMIN et OPERATEUR peuvent importer, LECTEUR est refusé |
+
+---
+
+### Frontend
+
+L’import CSV est disponible depuis la page détail d’un satellite.
+
+La section d’import permet :
+
+- de sélectionner un fichier CSV ;
+- d’afficher le format attendu ;
+- de lancer l’import ;
+- d’afficher un message de succès ;
+- d’afficher les erreurs ligne par ligne si le CSV est invalide.
+
+La section est disponible uniquement pour les rôles ADMIN et OPERATEUR sur un satellite actif.
+
+Pour un utilisateur LECTEUR, l’import n’est pas autorisé.
+
+---
+
+### Tests réalisés
+
+Les tests backend couvrent :
+
+- l’import d’un CSV valide ;
+- la persistance des points de télémétrie dans MongoDB ;
+- le rejet d’un header invalide ;
+- le rejet d’un timestamp invalide ;
+- le rejet d’une métrique vide ;
+- le rejet d’une valeur non numérique ;
+- le support d’un header CSV avec BOM UTF-8 ;
+- le rejet d’un fichier vide ;
+- le rejet d’un fichier non CSV ;
+- le rejet d’un satellite inexistant ;
+- le rejet d’un satellite inactif ;
+- le rejet d’une mission clôturée ;
+- le rejet d’un satellite qui n’appartient pas à la mission indiquée ;
+- les accès ADMIN, OPERATEUR, LECTEUR et non authentifié.
+
+Résultat backend :
+
+```text
+Tests run: 180, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+Le build frontend a également été validé :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+### Validation fonctionnelle
+
+La fonctionnalité a été validée manuellement dans Postman et dans le navigateur.
+
+Cas validés :
+
+- import CSV valide ;
+- stockage des documents dans MongoDB ;
+- vérification des documents dans la collection `telemetry_points` ;
+- import CSV invalide avec retour des erreurs ligne par ligne ;
+- absence de persistance partielle en cas d’erreur ;
+- affichage de l’interface d’import côté frontend ;
+- message de succès après import ;
+- affichage des erreurs CSV côté frontend ;
+- accès refusé pour le rôle LECTEUR.
+
+---
+
+### Limites actuelles
+
+L’US15 ne couvre pas encore :
+
+- la visualisation graphique des données de télémétrie ;
+- la détection automatique d’anomalies ;
+- la consultation détaillée des points de télémétrie ;
+- la pagination des données importées ;
+- la suppression de points de télémétrie ;
+- la mise à jour de points existants ;
+- l’import de formats autres que CSV ;
+- l’import en temps réel.
+
+Ces éléments sont prévus dans des user stories futures.
+
+---
+
+### Perspectives d’évolution
+
+Évolutions possibles :
+
+- ajouter des graphiques par métrique ;
+- afficher les données de télémétrie sur une période donnée ;
+- détecter les anomalies à partir de seuils configurables ;
+- ajouter un historique des imports ;
+- ajouter un détail d’import par `sourceImportId` ;
+- ajouter l’export des données importées.
+
+---
+
 ## Dashboard mission
 
 L’application permet de consulter un dashboard synthétique pour une mission.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -90,6 +90,18 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- MongoDB -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<!-- Log4j2 -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/finalspace/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/finalspace/backend/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.finalspace.backend.telemetry.TelemetryImportException;
+import com.finalspace.backend.telemetry.dto.TelemetryImportResponse;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -39,5 +42,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(errorMessage);
+    }
+
+    @ExceptionHandler(TelemetryImportException.class)
+    public ResponseEntity<TelemetryImportResponse> handleTelemetryImportException(
+            TelemetryImportException exception
+    ) {
+        return ResponseEntity.badRequest().body(
+                new TelemetryImportResponse(
+                        null,
+                        0,
+                        exception.getErrors().size(),
+                        exception.getErrors()
+                )
+        );
     }
 }

--- a/backend/src/main/java/com/finalspace/backend/satellite/SatelliteRepository.java
+++ b/backend/src/main/java/com/finalspace/backend/satellite/SatelliteRepository.java
@@ -1,7 +1,11 @@
 package com.finalspace.backend.satellite;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.List;
 
 public interface SatelliteRepository extends JpaRepository<Satellite, Long> {
@@ -11,4 +15,10 @@ public interface SatelliteRepository extends JpaRepository<Satellite, Long> {
     long countByMissionId(Long missionId);
 
     long countByMissionIdAndStatus(Long missionId, SatelliteStatus status);
+
+    @EntityGraph(attributePaths = "mission")
+    @Query("select s from Satellite s where s.id = :id")
+    Optional<Satellite> findByIdWithMission(@Param("id") Long id);
+
+
 }

--- a/backend/src/main/java/com/finalspace/backend/telemetry/TelemetryImportException.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/TelemetryImportException.java
@@ -1,0 +1,17 @@
+package com.finalspace.backend.telemetry;
+
+import com.finalspace.backend.telemetry.dto.TelemetryImportError;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class TelemetryImportException extends RuntimeException {
+
+    private final List<TelemetryImportError> errors;
+
+    public TelemetryImportException(List<TelemetryImportError> errors) {
+        super("Import CSV invalide");
+        this.errors = errors;
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/TelemetryPoint.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/TelemetryPoint.java
@@ -1,0 +1,41 @@
+package com.finalspace.backend.telemetry;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "telemetry_points")
+@CompoundIndex(
+        name = "idx_satellite_metric_timestamp",
+        def = "{'satelliteId': 1, 'metric': 1, 'timestamp': 1}"
+)
+public class TelemetryPoint {
+
+    @Id
+    private String id;
+
+    private Long missionId;
+
+    private Long satelliteId;
+
+    private Instant timestamp;
+
+    private String metric;
+
+    private Double value;
+
+    private String sourceImportId;
+
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/TelemetryPointRepository.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/TelemetryPointRepository.java
@@ -1,0 +1,12 @@
+package com.finalspace.backend.telemetry;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface TelemetryPointRepository extends MongoRepository<TelemetryPoint, String> {
+
+    List<TelemetryPoint> findBySatelliteIdOrderByTimestampDesc(Long satelliteId);
+
+    List<TelemetryPoint> findBySatelliteIdAndMetricOrderByTimestampAsc(Long satelliteId, String metric);
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/controller/TelemetryController.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/controller/TelemetryController.java
@@ -1,0 +1,26 @@
+package com.finalspace.backend.telemetry.controller;
+
+import com.finalspace.backend.telemetry.dto.TelemetryImportResponse;
+import com.finalspace.backend.telemetry.service.TelemetryImportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TelemetryController {
+
+    private final TelemetryImportService telemetryImportService;
+
+    @PostMapping("/missions/{missionId}/satellites/{satelliteId}/telemetry/import")
+    @ResponseStatus(HttpStatus.CREATED)
+    public TelemetryImportResponse importTelemetryCsv(
+            @PathVariable Long missionId,
+            @PathVariable Long satelliteId,
+            @RequestParam("file") MultipartFile file
+    ) {
+        return telemetryImportService.importCsv(missionId, satelliteId, file);
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/dto/TelemetryImportError.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/dto/TelemetryImportError.java
@@ -1,0 +1,7 @@
+package com.finalspace.backend.telemetry.dto;
+
+public record TelemetryImportError(
+        int line,
+        String message
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/dto/TelemetryImportResponse.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/dto/TelemetryImportResponse.java
@@ -1,0 +1,11 @@
+package com.finalspace.backend.telemetry.dto;
+
+import java.util.List;
+
+public record TelemetryImportResponse(
+        String importId,
+        int importedCount,
+        int errorCount,
+        List<TelemetryImportError> errors
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/service/TelemetryImportService.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/service/TelemetryImportService.java
@@ -1,0 +1,13 @@
+package com.finalspace.backend.telemetry.service;
+
+import com.finalspace.backend.telemetry.dto.TelemetryImportResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface TelemetryImportService {
+
+    TelemetryImportResponse importCsv(
+            Long missionId,
+            Long satelliteId,
+            MultipartFile file
+    );
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/service/impl/TelemetryImportServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/service/impl/TelemetryImportServiceImpl.java
@@ -1,0 +1,227 @@
+package com.finalspace.backend.telemetry.service.impl;
+
+import com.finalspace.backend.common.exception.BusinessException;
+import com.finalspace.backend.common.exception.ResourceNotFoundException;
+import com.finalspace.backend.mission.MissionStatus;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.satellite.SatelliteStatus;
+import com.finalspace.backend.telemetry.TelemetryImportException;
+import com.finalspace.backend.telemetry.TelemetryPoint;
+import com.finalspace.backend.telemetry.TelemetryPointRepository;
+import com.finalspace.backend.telemetry.dto.TelemetryImportError;
+import com.finalspace.backend.telemetry.dto.TelemetryImportResponse;
+import com.finalspace.backend.telemetry.service.TelemetryImportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TelemetryImportServiceImpl implements TelemetryImportService {
+
+    private static final String EXPECTED_HEADER = "timestamp,metric,value";
+
+    private final SatelliteRepository satelliteRepository;
+    private final TelemetryPointRepository telemetryPointRepository;
+
+    @Override
+    public TelemetryImportResponse importCsv(
+            Long missionId,
+            Long satelliteId,
+            MultipartFile file
+    ) {
+        Satellite satellite = satelliteRepository.findByIdWithMission(satelliteId)
+                .orElseThrow(() -> new ResourceNotFoundException("Satellite introuvable"));
+
+        validateSatelliteContext(missionId, satellite);
+        validateFile(file);
+
+        String importId = UUID.randomUUID().toString();
+        List<TelemetryImportError> errors = new ArrayList<>();
+        List<TelemetryPoint> points = parseCsv(missionId, satelliteId, file, importId, errors);
+
+        if (!errors.isEmpty()) {
+            throw new TelemetryImportException(errors);
+        }
+
+        telemetryPointRepository.saveAll(points);
+
+        return new TelemetryImportResponse(
+                importId,
+                points.size(),
+                0,
+                List.of()
+        );
+    }
+
+    private void validateSatelliteContext(Long missionId, Satellite satellite) {
+        if (satellite.getMission() == null || !satellite.getMission().getId().equals(missionId)) {
+            throw new BusinessException("Le satellite n'appartient pas à la mission indiquée");
+        }
+
+        if (satellite.getStatus() != SatelliteStatus.ACTIF) {
+            throw new BusinessException("Le satellite doit être actif pour importer des données de télémétrie");
+        }
+
+        if (satellite.getMission().getStatus() == MissionStatus.CLOTUREE) {
+            throw new BusinessException("La mission est clôturée");
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException("Le fichier CSV est obligatoire");
+        }
+
+        String filename = file.getOriginalFilename();
+
+        if (filename == null || !filename.toLowerCase().endsWith(".csv")) {
+            throw new BusinessException("Le fichier doit être au format CSV");
+        }
+    }
+
+    private List<TelemetryPoint> parseCsv(
+            Long missionId,
+            Long satelliteId,
+            MultipartFile file,
+            String importId,
+            List<TelemetryImportError> errors
+    ) {
+        List<TelemetryPoint> points = new ArrayList<>();
+
+        try (
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8)
+                )
+        ) {
+            String header = reader.readLine();
+
+            if (header == null || !EXPECTED_HEADER.equals(normalizeCsvValue(header))) {
+                errors.add(new TelemetryImportError(
+                        1,
+                        "Header CSV invalide. Format attendu : timestamp,metric,value"
+                ));
+                return points;
+            }
+
+            String line;
+            int lineNumber = 1;
+
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+
+                if (line.isBlank()) {
+                    continue;
+                }
+
+                String[] columns = line.split(",", -1);
+
+                if (columns.length != 3) {
+                    errors.add(new TelemetryImportError(
+                            lineNumber,
+                            "La ligne doit contenir exactement 3 colonnes"
+                    ));
+                    continue;
+                }
+
+                Instant timestamp = parseTimestamp(columns[0], lineNumber, errors);
+                String metric = parseMetric(columns[1], lineNumber, errors);
+                Double value = parseValue(columns[2], lineNumber, errors);
+
+                if (timestamp == null || metric == null || value == null) {
+                    continue;
+                }
+
+                points.add(TelemetryPoint.builder()
+                        .missionId(missionId)
+                        .satelliteId(satelliteId)
+                        .timestamp(timestamp)
+                        .metric(metric)
+                        .value(value)
+                        .sourceImportId(importId)
+                        .createdAt(LocalDateTime.now())
+                        .build());
+            }
+        } catch (Exception exception) {
+            errors.add(new TelemetryImportError(
+                    0,
+                    "Impossible de lire le fichier CSV"
+            ));
+        }
+
+        if (points.isEmpty() && errors.isEmpty()) {
+            errors.add(new TelemetryImportError(
+                    0,
+                    "Le fichier CSV ne contient aucune donnée"
+            ));
+        }
+
+        return points;
+    }
+
+    private Instant parseTimestamp(
+            String rawTimestamp,
+            int lineNumber,
+            List<TelemetryImportError> errors
+    ) {
+        try {
+            return Instant.parse(normalizeCsvValue(rawTimestamp));
+        } catch (Exception exception) {
+            errors.add(new TelemetryImportError(
+                    lineNumber,
+                    "Timestamp invalide. Format attendu : ISO-8601, exemple 2026-01-01T10:00:00Z"
+            ));
+            return null;
+        }
+    }
+
+    private String parseMetric(
+            String rawMetric,
+            int lineNumber,
+            List<TelemetryImportError> errors
+    ) {
+        String metric = normalizeCsvValue(rawMetric);
+
+        if (metric.isBlank()) {
+            errors.add(new TelemetryImportError(
+                    lineNumber,
+                    "La métrique est obligatoire"
+            ));
+            return null;
+        }
+
+        return metric;
+    }
+
+    private Double parseValue(
+            String rawValue,
+            int lineNumber,
+            List<TelemetryImportError> errors
+    ) {
+        try {
+            return Double.parseDouble(normalizeCsvValue(rawValue));
+        } catch (Exception exception) {
+            errors.add(new TelemetryImportError(
+                    lineNumber,
+                    "La valeur doit être numérique"
+            ));
+            return null;
+        }
+    }
+
+    private String normalizeCsvValue(String value) {
+        return value == null
+                ? ""
+                : value.replace("\uFEFF", "").trim();
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,6 +7,8 @@ spring.datasource.password=finalspace
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+spring.mongodb.uri=mongodb://finalspace:finalspace@localhost:27017/finalspace?authSource=admin
+
 # ===============================
 # JPA / HIBERNATE
 # ===============================

--- a/backend/src/test/java/com/finalspace/backend/security/TelemetryImportAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/finalspace/backend/security/TelemetryImportAuthorizationIntegrationTest.java
@@ -1,0 +1,281 @@
+package com.finalspace.backend.security;
+
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.mission.MissionRepository;
+import com.finalspace.backend.mission.MissionStatus;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.satellite.SatelliteStatus;
+import com.finalspace.backend.telemetry.TelemetryPointRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import tools.jackson.databind.JsonNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TelemetryImportAuthorizationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private SatelliteRepository satelliteRepository;
+
+    @Autowired
+    private TelemetryPointRepository telemetryPointRepository;
+
+    private final JsonMapper jsonMapper = new JsonMapper();
+
+    @BeforeEach
+    void cleanDatabase() {
+        telemetryPointRepository.deleteAll();
+        satelliteRepository.deleteAll();
+        missionRepository.deleteAll();
+    }
+
+    @Test
+    void adminShouldImportTelemetryCsv() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(validCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.importId").isString())
+                .andExpect(jsonPath("$.importedCount").value(2))
+                .andExpect(jsonPath("$.errorCount").value(0))
+                .andExpect(jsonPath("$.errors").isArray())
+                .andExpect(jsonPath("$.errors.length()").value(0));
+
+        assertThat(telemetryPointRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()))
+                .hasSize(2);
+    }
+
+    @Test
+    void operatorShouldImportTelemetryCsv() throws Exception {
+        String token = loginAndGetToken("operator@finalspace.com", "operator123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(validCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.importedCount").value(2))
+                .andExpect(jsonPath("$.errorCount").value(0));
+
+        assertThat(telemetryPointRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()))
+                .hasSize(2);
+    }
+
+    @Test
+    void readerShouldNotImportTelemetryCsv() throws Exception {
+        String token = loginAndGetToken("reader@finalspace.com", "reader123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(validCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+
+        assertThat(telemetryPointRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    void unauthenticatedUserShouldNotImportTelemetryCsv() throws Exception {
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(validCsvFile()))
+                .andExpect(status().isUnauthorized());
+
+        assertThat(telemetryPointRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    void shouldRejectInvalidCsvAndNotPersistPartialData() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(invalidCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.importId").doesNotExist())
+                .andExpect(jsonPath("$.importedCount").value(0))
+                .andExpect(jsonPath("$.errorCount").value(3))
+                .andExpect(jsonPath("$.errors").isArray())
+                .andExpect(jsonPath("$.errors[0].line").value(3))
+                .andExpect(jsonPath("$.errors[1].line").value(4))
+                .andExpect(jsonPath("$.errors[2].line").value(5));
+
+        assertThat(telemetryPointRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    void shouldRejectImportForInactiveSatellite() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createInactiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(validCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+
+        assertThat(telemetryPointRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    void shouldRejectImportForClosedMission() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createSatelliteOnClosedMission();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(validCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+
+        assertThat(telemetryPointRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    void shouldRejectImportWhenSatelliteDoesNotBelongToMission() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        99999L,
+                        satellite.getId())
+                        .file(validCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+
+        assertThat(telemetryPointRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()))
+                .isEmpty();
+    }
+
+    private String loginAndGetToken(String email, String password) throws Exception {
+        String request = """
+            {
+              "email": "%s",
+              "password": "%s"
+            }
+            """.formatted(email, password);
+
+        String response = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode responseJson = jsonMapper.readTree(response);
+
+        return responseJson.get("token").asString();
+    }
+
+    private MockMultipartFile validCsvFile() {
+        return new MockMultipartFile(
+                "file",
+                "telemetry-valid.csv",
+                "text/csv",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                2026-01-01T10:00:00Z,battery,78
+                """.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    private MockMultipartFile invalidCsvFile() {
+        return new MockMultipartFile(
+                "file",
+                "telemetry-invalid.csv",
+                "text/csv",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                date-invalide,battery,78
+                2026-01-01T10:05:00Z,,91
+                2026-01-01T10:10:00Z,speed,abc
+                """.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    private Satellite createActiveSatellite() {
+        return createSatellite(SatelliteStatus.ACTIF, MissionStatus.ACTIVE);
+    }
+
+    private Satellite createInactiveSatellite() {
+        return createSatellite(SatelliteStatus.INACTIF, MissionStatus.ACTIVE);
+    }
+
+    private Satellite createSatelliteOnClosedMission() {
+        return createSatellite(SatelliteStatus.ACTIF, MissionStatus.CLOTUREE);
+    }
+
+    private Satellite createSatellite(SatelliteStatus satelliteStatus, MissionStatus missionStatus) {
+        Mission mission = Mission.builder()
+                .name("Mission Telemetry")
+                .description("Mission utilisée pour les tests telemetry")
+                .status(missionStatus)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Mission savedMission = missionRepository.save(mission);
+
+        Satellite satellite = Satellite.builder()
+                .name("TelemetrySat")
+                .status(satelliteStatus)
+                .massKg(850.0)
+                .altitudeKm(500.0)
+                .inclinationDeg(95.0)
+                .eccentricity(0.4)
+                .mission(savedMission)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        return satelliteRepository.save(satellite);
+    }
+}

--- a/backend/src/test/java/com/finalspace/backend/telemetry/service/impl/TelemetryImportServiceImplTest.java
+++ b/backend/src/test/java/com/finalspace/backend/telemetry/service/impl/TelemetryImportServiceImplTest.java
@@ -1,0 +1,322 @@
+package com.finalspace.backend.telemetry.service.impl;
+
+import com.finalspace.backend.common.exception.BusinessException;
+import com.finalspace.backend.common.exception.ResourceNotFoundException;
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.mission.MissionStatus;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.satellite.SatelliteStatus;
+import com.finalspace.backend.telemetry.TelemetryImportException;
+import com.finalspace.backend.telemetry.TelemetryPoint;
+import com.finalspace.backend.telemetry.TelemetryPointRepository;
+import com.finalspace.backend.telemetry.dto.TelemetryImportResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TelemetryImportServiceImplTest {
+
+    @Mock
+    private SatelliteRepository satelliteRepository;
+
+    @Mock
+    private TelemetryPointRepository telemetryPointRepository;
+
+    @InjectMocks
+    private TelemetryImportServiceImpl telemetryImportService;
+
+    @Test
+    void shouldImportValidCsvAndPersistTelemetryPoints() {
+        Satellite satellite = activeSatellite();
+
+        MockMultipartFile file = csvFile(
+                "telemetry-valid.csv",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                2026-01-01T10:00:00Z,battery,78
+                """
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+        when(telemetryPointRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TelemetryImportResponse response = telemetryImportService.importCsv(4L, 3L, file);
+
+        assertThat(response.importId()).isNotBlank();
+        assertThat(response.importedCount()).isEqualTo(2);
+        assertThat(response.errorCount()).isZero();
+        assertThat(response.errors()).isEmpty();
+
+        ArgumentCaptor<List<TelemetryPoint>> captor = ArgumentCaptor.forClass(List.class);
+        verify(telemetryPointRepository).saveAll(captor.capture());
+
+        List<TelemetryPoint> savedPoints = captor.getValue();
+
+        assertThat(savedPoints).hasSize(2);
+
+        assertThat(savedPoints.get(0).getMissionId()).isEqualTo(4L);
+        assertThat(savedPoints.get(0).getSatelliteId()).isEqualTo(3L);
+        assertThat(savedPoints.get(0).getTimestamp()).isEqualTo(Instant.parse("2026-01-01T10:00:00Z"));
+        assertThat(savedPoints.get(0).getMetric()).isEqualTo("temperature");
+        assertThat(savedPoints.get(0).getValue()).isEqualTo(42.5);
+        assertThat(savedPoints.get(0).getSourceImportId()).isEqualTo(response.importId());
+
+        assertThat(savedPoints.get(1).getMetric()).isEqualTo("battery");
+        assertThat(savedPoints.get(1).getValue()).isEqualTo(78.0);
+        assertThat(savedPoints.get(1).getSourceImportId()).isEqualTo(response.importId());
+    }
+
+    @Test
+    void shouldRejectCsvWithInvalidHeaderAndNotPersistAnything() {
+        Satellite satellite = activeSatellite();
+
+        MockMultipartFile file = csvFile(
+                "telemetry-invalid.csv",
+                """
+                date,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                """
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+
+        assertThatThrownBy(() -> telemetryImportService.importCsv(4L, 3L, file))
+                .isInstanceOf(TelemetryImportException.class)
+                .satisfies(exception -> {
+                    TelemetryImportException importException = (TelemetryImportException) exception;
+
+                    assertThat(importException.getErrors()).hasSize(1);
+                    assertThat(importException.getErrors().get(0).line()).isEqualTo(1);
+                    assertThat(importException.getErrors().get(0).message())
+                            .isEqualTo("Header CSV invalide. Format attendu : timestamp,metric,value");
+                });
+
+        verify(telemetryPointRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void shouldRejectCsvWithInvalidRowsAndNotPersistAnything() {
+        Satellite satellite = activeSatellite();
+
+        MockMultipartFile file = csvFile(
+                "telemetry-invalid.csv",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                date-invalide,battery,78
+                2026-01-01T10:05:00Z,,91
+                2026-01-01T10:10:00Z,speed,abc
+                """
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+
+        assertThatThrownBy(() -> telemetryImportService.importCsv(4L, 3L, file))
+                .isInstanceOf(TelemetryImportException.class)
+                .satisfies(exception -> {
+                    TelemetryImportException importException = (TelemetryImportException) exception;
+
+                    assertThat(importException.getErrors()).hasSize(3);
+
+                    assertThat(importException.getErrors().get(0).line()).isEqualTo(3);
+                    assertThat(importException.getErrors().get(0).message())
+                            .isEqualTo("Timestamp invalide. Format attendu : ISO-8601, exemple 2026-01-01T10:00:00Z");
+
+                    assertThat(importException.getErrors().get(1).line()).isEqualTo(4);
+                    assertThat(importException.getErrors().get(1).message())
+                            .isEqualTo("La métrique est obligatoire");
+
+                    assertThat(importException.getErrors().get(2).line()).isEqualTo(5);
+                    assertThat(importException.getErrors().get(2).message())
+                            .isEqualTo("La valeur doit être numérique");
+                });
+
+        verify(telemetryPointRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void shouldSupportUtf8BomInCsvHeader() {
+        Satellite satellite = activeSatellite();
+
+        MockMultipartFile file = csvFile(
+                "telemetry-valid.csv",
+                "\uFEFFtimestamp,metric,value\n" +
+                        "2026-01-01T10:00:00Z,temperature,42.5\n"
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+        when(telemetryPointRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TelemetryImportResponse response = telemetryImportService.importCsv(4L, 3L, file);
+
+        assertThat(response.importedCount()).isEqualTo(1);
+        assertThat(response.errorCount()).isZero();
+
+        verify(telemetryPointRepository).saveAll(anyList());
+    }
+
+    @Test
+    void shouldRejectEmptyCsvFile() {
+        Satellite satellite = activeSatellite();
+
+        MockMultipartFile file = csvFile(
+                "telemetry-empty.csv",
+                ""
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+
+        assertThatThrownBy(() -> telemetryImportService.importCsv(4L, 3L, file))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Le fichier CSV est obligatoire");
+
+        verify(telemetryPointRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void shouldRejectNonCsvFile() {
+        Satellite satellite = activeSatellite();
+
+        MockMultipartFile file = csvFile(
+                "telemetry.txt",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                """
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+
+        assertThatThrownBy(() -> telemetryImportService.importCsv(4L, 3L, file))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Le fichier doit être au format CSV");
+
+        verify(telemetryPointRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void shouldRejectUnknownSatellite() {
+        MockMultipartFile file = csvFile(
+                "telemetry-valid.csv",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                """
+        );
+
+        when(satelliteRepository.findByIdWithMission(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> telemetryImportService.importCsv(4L, 99L, file))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Satellite introuvable");
+
+        verify(telemetryPointRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void shouldRejectSatelliteThatDoesNotBelongToMission() {
+        Satellite satellite = activeSatellite();
+
+        MockMultipartFile file = csvFile(
+                "telemetry-valid.csv",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                """
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+
+        assertThatThrownBy(() -> telemetryImportService.importCsv(999L, 3L, file))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Le satellite n'appartient pas à la mission indiquée");
+
+        verify(telemetryPointRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void shouldRejectInactiveSatellite() {
+        Satellite satellite = satelliteWithStatus(SatelliteStatus.INACTIF, MissionStatus.ACTIVE);
+
+        MockMultipartFile file = csvFile(
+                "telemetry-valid.csv",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                """
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+
+        assertThatThrownBy(() -> telemetryImportService.importCsv(4L, 3L, file))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Le satellite doit être actif pour importer des données de télémétrie");
+
+        verify(telemetryPointRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void shouldRejectClosedMission() {
+        Satellite satellite = satelliteWithStatus(SatelliteStatus.ACTIF, MissionStatus.CLOTUREE);
+
+        MockMultipartFile file = csvFile(
+                "telemetry-valid.csv",
+                """
+                timestamp,metric,value
+                2026-01-01T10:00:00Z,temperature,42.5
+                """
+        );
+
+        when(satelliteRepository.findByIdWithMission(3L)).thenReturn(Optional.of(satellite));
+
+        assertThatThrownBy(() -> telemetryImportService.importCsv(4L, 3L, file))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("La mission est clôturée");
+
+        verify(telemetryPointRepository, never()).saveAll(anyList());
+    }
+
+    private MockMultipartFile csvFile(String filename, String content) {
+        return new MockMultipartFile(
+                "file",
+                filename,
+                "text/csv",
+                content.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    private Satellite activeSatellite() {
+        return satelliteWithStatus(SatelliteStatus.ACTIF, MissionStatus.ACTIVE);
+    }
+
+    private Satellite satelliteWithStatus(SatelliteStatus satelliteStatus, MissionStatus missionStatus) {
+        Mission mission = Mission.builder()
+                .id(4L)
+                .name("Mission to the MOOOOON")
+                .status(missionStatus)
+                .build();
+
+        return Satellite.builder()
+                .id(3L)
+                .name("LunaSat-03")
+                .status(satelliteStatus)
+                .mission(mission)
+                .build();
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -3,6 +3,8 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 
+spring.mongodb.uri=mongodb://finalspace:finalspace@localhost:27017/finalspace_test?authSource=admin
+
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,36 @@ services:
       timeout: 5s
       retries: 5
 
+  mongodb:
+    image: mongo:7
+    container_name: finalspace-mongodb
+
+    restart: unless-stopped
+
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: finalspace
+      MONGO_INITDB_ROOT_PASSWORD: finalspace
+      MONGO_INITDB_DATABASE: finalspace
+
+    ports:
+      - "27017:27017"
+
+    volumes:
+      - mongodb_data:/data/db
+
+    networks:
+      - finalspace-network
+
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --username finalspace --password finalspace --authenticationDatabase admin --eval 'db.adminCommand({ ping: 1 })'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 
 volumes:
   postgres_data:
+  mongodb_data:
 
 
 networks:

--- a/docs/tests/US15-tests.md
+++ b/docs/tests/US15-tests.md
@@ -1,0 +1,375 @@
+# US15 - Importer des données de télémétrie au format CSV
+
+## État de validation
+
+**US15 validée côté backend et frontend.**
+
+L’application permet à un administrateur ou à un opérateur d’importer des données de télémétrie au format CSV pour un satellite actif.
+
+Les données sont persistées dans MongoDB, dans la collection `telemetry_points`.
+
+---
+
+## Objectif de l’US
+
+Permettre l’import de données de télémétrie au format CSV afin de préparer leur visualisation et leur analyse.
+
+Les données importées sont associées :
+
+- à une mission ;
+- à un satellite ;
+- à un import identifié par un `sourceImportId`.
+
+---
+
+## Dépendances
+
+| User Story | Description | État |
+|---|---|---|
+| US06 | Gestion des satellites | Validée |
+| US15 | Import CSV télémétrie | En cours de validation |
+
+---
+
+## Choix d’architecture
+
+L’US15 introduit une base de données non relationnelle dans le projet.
+
+Le choix retenu est :
+
+| Base | Usage |
+|---|---|
+| PostgreSQL | Données métier relationnelles |
+| MongoDB | Données de télémétrie temporelles |
+
+Les données de télémétrie sont stockées dans MongoDB car elles sont :
+
+- temporelles ;
+- potentiellement volumineuses ;
+- fortement liées à des métriques ;
+- adaptées à un stockage documentaire ;
+- destinées à être exploitées ensuite pour des graphiques et de l’analyse.
+
+---
+
+## Collection MongoDB
+
+Collection utilisée :
+
+```text
+telemetry_points
+```
+
+Document MongoDB :
+
+```json
+{
+  "id": "...",
+  "missionId": 4,
+  "satelliteId": 3,
+  "timestamp": "2026-01-01T10:00:00Z",
+  "metric": "temperature",
+  "value": 42.5,
+  "sourceImportId": "a8c9129a-2002-491a-a61a-7ddf4fe3373c",
+  "createdAt": "2026-06-21T11:28:30Z"
+}
+```
+
+Index défini :
+
+```text
+satelliteId, metric, timestamp
+```
+
+---
+
+## Format CSV attendu
+
+Le fichier CSV doit contenir le header suivant :
+
+```csv
+timestamp,metric,value
+```
+
+Exemple de fichier valide :
+
+```csv
+timestamp,metric,value
+2026-01-01T10:00:00Z,temperature,42.5
+2026-01-01T10:00:00Z,battery,78
+```
+
+---
+
+## Endpoint testé
+
+| Méthode | Endpoint | Description |
+|---|---|---|
+| `POST` | `/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import` | Importer un fichier CSV de télémétrie |
+
+Le endpoint attend une requête `multipart/form-data` avec une clé :
+
+```text
+file
+```
+
+---
+
+## DTO de réponse
+
+Réponse en cas de succès :
+
+```json
+{
+  "importId": "a8c9129a-2002-491a-a61a-7ddf4fe3373c",
+  "importedCount": 2,
+  "errorCount": 0,
+  "errors": []
+}
+```
+
+Réponse en cas d’erreur CSV :
+
+```json
+{
+  "importId": null,
+  "importedCount": 0,
+  "errorCount": 3,
+  "errors": [
+    {
+      "line": 3,
+      "message": "Timestamp invalide. Format attendu : ISO-8601, exemple 2026-01-01T10:00:00Z"
+    },
+    {
+      "line": 4,
+      "message": "La métrique est obligatoire"
+    },
+    {
+      "line": 5,
+      "message": "La valeur doit être numérique"
+    }
+  ]
+}
+```
+
+---
+
+## Règles métier couvertes
+
+| Référence | Règle | État |
+|---|---|---|
+| RG-TEL-01 | Le fichier doit être au format CSV | PASS |
+| RG-TEL-02 | Le header doit être `timestamp,metric,value` | PASS |
+| RG-TEL-03 | Le timestamp doit être valide | PASS |
+| RG-TEL-04 | La métrique ne doit pas être vide | PASS |
+| RG-TEL-05 | La valeur doit être numérique | PASS |
+| RG-TEL-06 | Le satellite doit exister | PASS |
+| RG-TEL-07 | Le satellite doit être actif | PASS |
+| RG-TEL-08 | Le satellite doit appartenir à la mission indiquée | PASS |
+| RG-TEL-09 | La mission ne doit pas être clôturée | PASS |
+| RG-TEL-10 | Aucune donnée partielle n’est persistée en cas d’erreur | PASS |
+| RG-TEL-11 | ADMIN peut importer | PASS |
+| RG-TEL-12 | OPERATEUR peut importer | PASS |
+| RG-TEL-13 | LECTEUR ne peut pas importer | PASS |
+| RG-TEL-14 | Un utilisateur non authentifié ne peut pas importer | PASS |
+
+---
+
+## Tests unitaires - TelemetryImportServiceImplTest
+
+Classe associée :
+
+```text
+backend/src/test/java/com/finalspace/backend/telemetry/service/impl/TelemetryImportServiceImplTest.java
+```
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US15-T01 | Importer un CSV valide | Points persistés dans MongoDB | PASS |
+| US15-T02 | Header CSV invalide | Import rejeté | PASS |
+| US15-T03 | Lignes CSV invalides | Import rejeté avec erreurs ligne par ligne | PASS |
+| US15-T04 | Header avec BOM UTF-8 | Import accepté | PASS |
+| US15-T05 | Fichier vide | Import rejeté | PASS |
+| US15-T06 | Fichier non CSV | Import rejeté | PASS |
+| US15-T07 | Satellite inexistant | Import rejeté | PASS |
+| US15-T08 | Satellite rattaché à une autre mission | Import rejeté | PASS |
+| US15-T09 | Satellite inactif | Import rejeté | PASS |
+| US15-T10 | Mission clôturée | Import rejeté | PASS |
+
+---
+
+## Tests d’intégration API / sécurité
+
+Classe associée :
+
+```text
+backend/src/test/java/com/finalspace/backend/security/TelemetryImportAuthorizationIntegrationTest.java
+```
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US15-T11 | ADMIN importe un CSV valide | `201 Created` | PASS |
+| US15-T12 | OPERATEUR importe un CSV valide | `201 Created` | PASS |
+| US15-T13 | LECTEUR tente d’importer un CSV | `403 Forbidden` | PASS |
+| US15-T14 | Utilisateur non authentifié tente d’importer | `401 Unauthorized` | PASS |
+| US15-T15 | CSV invalide | `400 Bad Request` | PASS |
+| US15-T16 | Satellite inactif | `400 Bad Request` | PASS |
+| US15-T17 | Mission clôturée | `400 Bad Request` | PASS |
+| US15-T18 | Satellite hors mission | `400 Bad Request` | PASS |
+
+---
+
+## Tests Postman réalisés
+
+| Scénario | Résultat attendu | État |
+|---|---|---|
+| Import CSV valide avec ADMIN | `201 Created` | PASS |
+| Import CSV valide avec OPERATEUR | `201 Created` | PASS |
+| Import CSV invalide | `400 Bad Request` avec erreurs détaillées | PASS |
+| Vérification MongoDB après import valide | 2 documents présents | PASS |
+| Vérification MongoDB après import invalide | Aucun document supplémentaire | PASS |
+
+---
+
+## Vérification MongoDB
+
+Commande utilisée :
+
+```bash
+docker exec -it finalspace-mongodb mongosh --username finalspace --password finalspace --authenticationDatabase admin
+```
+
+Commandes Mongo :
+
+```javascript
+use finalspace
+db.telemetry_points.find().pretty()
+```
+
+Résultat observé :
+
+```text
+2 documents présents dans telemetry_points
+```
+
+Les documents contiennent :
+
+- `missionId` ;
+- `satelliteId` ;
+- `timestamp` ;
+- `metric` ;
+- `value` ;
+- `sourceImportId` ;
+- `createdAt`.
+
+---
+
+## Tests frontend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US15-T19 | Afficher la section import CSV | Section visible pour ADMIN / OPERATEUR | PASS |
+| US15-T20 | Sélectionner un fichier CSV | Nom du fichier affiché | PASS |
+| US15-T21 | Importer un CSV valide | Message de succès affiché | PASS |
+| US15-T22 | Importer un CSV invalide | Erreurs ligne par ligne affichées | PASS |
+| US15-T23 | Accès LECTEUR | Import non autorisé | PASS |
+| US15-T24 | Build Angular | Build OK | PASS |
+
+---
+
+## Résultat d’exécution automatisée
+
+Commande backend :
+
+```bash
+./mvnw clean test
+```
+
+Résultat :
+
+```text
+Tests run: 180, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+Commande frontend :
+
+```bash
+npm run build
+```
+
+Résultat :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+## Points techniques importants
+
+### Configuration MongoDB Spring Boot 4
+
+La configuration MongoDB utilisée est :
+
+```properties
+spring.mongodb.uri=mongodb://finalspace:finalspace@localhost:27017/finalspace?authSource=admin
+```
+
+La propriété `spring.data.mongodb.uri` n’est pas utilisée dans ce projet Spring Boot 4.
+
+### Chargement de la mission du satellite
+
+Pour éviter une erreur `LazyInitializationException`, le repository satellite expose une méthode chargeant le satellite avec sa mission :
+
+```java
+Optional<Satellite> findByIdWithMission(Long id);
+```
+
+Cela permet de valider :
+
+- le rattachement mission / satellite ;
+- le statut de la mission ;
+- le statut du satellite.
+
+### Gestion du BOM UTF-8
+
+L’import CSV supporte les fichiers contenant un BOM UTF-8 au début du header.
+
+---
+
+## Sécurité
+
+| Rôle | Import CSV |
+|---|---|
+| ADMIN | Autorisé |
+| OPERATEUR | Autorisé |
+| LECTEUR | Refusé |
+| Non authentifié | Refusé |
+
+---
+
+## Hors périmètre
+
+Les éléments suivants ne sont pas couverts par l’US15 :
+
+- visualisation graphique des données ;
+- détection automatique d’anomalies ;
+- import temps réel ;
+- modification de points existants ;
+- suppression de points existants ;
+- import de fichiers autres que CSV ;
+- historisation détaillée des imports ;
+- pagination des points de télémétrie.
+
+---
+
+## Conclusion
+
+L’US15 est terminée côté backend et frontend.
+
+Le projet utilise désormais MongoDB pour stocker les données de télémétrie.
+
+L’import CSV est fonctionnel, sécurisé et validé par tests automatisés.
+
+Les données importées sont disponibles pour les prochaines user stories de visualisation et de détection d’anomalies.

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.css
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.css
@@ -472,3 +472,115 @@ input:focus {
   color: #bfdbfe;
   text-decoration: underline;
 }
+
+.telemetry-import-section {
+  margin-top: 32px;
+  padding: 24px;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.telemetry-import-form {
+  margin-top: 20px;
+}
+
+.telemetry-format-card {
+  margin-bottom: 20px;
+  padding: 18px;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.62);
+}
+
+.telemetry-format-card h3 {
+  margin: 0 0 12px;
+  color: #f8fafc;
+  font-size: 18px;
+}
+
+.telemetry-format-card pre {
+  margin: 0;
+  padding: 14px;
+  overflow-x: auto;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  color: #cbd5e1;
+  background: rgba(15, 23, 42, 0.9);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.selected-file-card {
+  margin-top: 16px;
+  padding: 14px 16px;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 12px;
+  color: #bae6fd;
+  background: rgba(2, 132, 199, 0.16);
+}
+
+.selected-file-card strong {
+  color: #f8fafc;
+}
+
+.telemetry-error-list {
+  margin-top: 20px;
+  padding: 18px;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: 14px;
+  background: rgba(127, 29, 29, 0.16);
+}
+
+.telemetry-error-list h3 {
+  margin: 0 0 14px;
+  color: #fecaca;
+  font-size: 18px;
+}
+
+.telemetry-error-table {
+  width: 100%;
+  border-collapse: collapse;
+  overflow: hidden;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.7);
+}
+
+.telemetry-error-table th,
+.telemetry-error-table td {
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid rgba(248, 113, 113, 0.18);
+}
+
+.telemetry-error-table th {
+  color: #fecaca;
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(127, 29, 29, 0.35);
+}
+
+.telemetry-error-table td {
+  color: #fee2e2;
+  font-size: 14px;
+}
+
+.telemetry-error-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.telemetry-result-card {
+  margin-top: 20px;
+  padding: 18px;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  border-radius: 14px;
+  background: rgba(22, 163, 74, 0.14);
+}
+
+.telemetry-result-card h3 {
+  margin: 0 0 14px;
+  color: #bbf7d0;
+  font-size: 18px;
+}

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.html
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.html
@@ -490,6 +490,118 @@
         </div>
       </div>
     </section>
+    <section class="telemetry-import-section">
+      <div class="simulation-header">
+        <div>
+          <h2>Import de télémétrie CSV</h2>
+          <p>
+            Importe des mesures temporelles associées à ce satellite pour préparer la visualisation
+            et la détection d’anomalies.
+          </p>
+        </div>
+      </div>
+
+      <div *ngIf="!canImportTelemetry()" class="info-card">
+        L’import de télémétrie est disponible uniquement pour un administrateur ou un opérateur,
+        sur un satellite actif.
+      </div>
+
+      <form
+        *ngIf="canImportTelemetry()"
+        class="telemetry-import-form"
+        (ngSubmit)="importTelemetryCsv()"
+      >
+        <div class="telemetry-format-card">
+          <h3>Format CSV attendu</h3>
+
+          <pre>timestamp,metric,value
+2026-01-01T10:00:00Z,temperature,42.5
+2026-01-01T10:00:00Z,battery,78</pre>
+        </div>
+
+        <div class="form-grid">
+          <div class="form-group">
+            <label for="telemetryCsvFile">Fichier CSV</label>
+            <input
+              id="telemetryCsvFile"
+              name="telemetryCsvFile"
+              type="file"
+              accept=".csv,text/csv"
+              (change)="onTelemetryFileSelected($event)"
+            />
+          </div>
+
+          <div class="form-group readonly-field">
+            <label>Satellite cible</label>
+            <strong>{{ satellite.name }}</strong>
+          </div>
+        </div>
+
+        <div *ngIf="selectedTelemetryFile" class="selected-file-card">
+          Fichier sélectionné :
+          <strong>{{ selectedTelemetryFile.name }}</strong>
+        </div>
+
+        <div class="actions">
+          <button
+            type="submit"
+            class="primary-button"
+            [disabled]="telemetryImporting"
+          >
+            {{ telemetryImporting ? 'Import en cours...' : 'Importer le CSV' }}
+          </button>
+        </div>
+      </form>
+
+      <div *ngIf="telemetryImportSuccessMessage" class="success-card">
+        {{ telemetryImportSuccessMessage }}
+      </div>
+
+      <div *ngIf="telemetryImportErrorMessage" class="error-card">
+        {{ telemetryImportErrorMessage }}
+      </div>
+
+      <div *ngIf="telemetryImportErrors.length > 0" class="telemetry-error-list">
+        <h3>Erreurs détectées</h3>
+
+        <table class="telemetry-error-table">
+          <thead>
+          <tr>
+            <th>Ligne</th>
+            <th>Message</th>
+          </tr>
+          </thead>
+
+          <tbody>
+          <tr *ngFor="let error of telemetryImportErrors">
+            <td>{{ error.line }}</td>
+            <td>{{ error.message }}</td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div *ngIf="telemetryImportResult" class="telemetry-result-card">
+        <h3>Import terminé</h3>
+
+        <div class="result-grid">
+          <div>
+            <span>Import ID</span>
+            <strong>{{ telemetryImportResult.importId }}</strong>
+          </div>
+
+          <div>
+            <span>Points importés</span>
+            <strong>{{ telemetryImportResult.importedCount }}</strong>
+          </div>
+
+          <div>
+            <span>Erreurs</span>
+            <strong>{{ telemetryImportResult.errorCount }}</strong>
+          </div>
+        </div>
+      </div>
+    </section>
     <section class="simulation-history-section">
       <div class="simulation-header">
         <div>

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.ts
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.ts
@@ -12,6 +12,11 @@ import {
   SimulationResponse,
   OrbitPlotPoint
 } from '../../simulations/models/simulation.model';
+import { TelemetryService } from '../../telemetry/services/telemetry.service';
+import {
+  TelemetryImportError,
+  TelemetryImportResponse
+} from '../../telemetry/models/telemetry-import.model';
 
 @Component({
   selector: 'app-satellite-detail',
@@ -51,11 +56,19 @@ export class SatelliteDetailComponent implements OnInit {
   simulationHistoryLoading = false;
   simulationHistoryErrorMessage = '';
 
+  selectedTelemetryFile: File | null = null;
+  telemetryImporting = false;
+  telemetryImportSuccessMessage = '';
+  telemetryImportErrorMessage = '';
+  telemetryImportErrors: TelemetryImportError[] = [];
+  telemetryImportResult: TelemetryImportResponse | null = null;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private satelliteService: SatelliteService,
     private simulationService: SimulationService,
+    private telemetryService: TelemetryService,
     private authService: AuthService
   ) {}
 
@@ -491,5 +504,80 @@ export class SatelliteDetailComponent implements OnInit {
     }
 
     return type;
+  }
+
+  canImportTelemetry(): boolean {
+    return this.canManage() && this.satellite?.status === 'ACTIF';
+  }
+
+  onTelemetryFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0] ?? null;
+
+    this.selectedTelemetryFile = file;
+    this.telemetryImportSuccessMessage = '';
+    this.telemetryImportErrorMessage = '';
+    this.telemetryImportErrors = [];
+    this.telemetryImportResult = null;
+  }
+
+  importTelemetryCsv(): void {
+    if (!this.satellite || !this.canImportTelemetry()) {
+      return;
+    }
+
+    if (!this.selectedTelemetryFile) {
+      this.telemetryImportErrorMessage = 'Veuillez sélectionner un fichier CSV.';
+      this.telemetryImportErrors = [];
+      return;
+    }
+
+    if (!this.selectedTelemetryFile.name.toLowerCase().endsWith('.csv')) {
+      this.telemetryImportErrorMessage = 'Le fichier doit être au format CSV.';
+      this.telemetryImportErrors = [];
+      return;
+    }
+
+    this.telemetryImporting = true;
+    this.telemetryImportSuccessMessage = '';
+    this.telemetryImportErrorMessage = '';
+    this.telemetryImportErrors = [];
+    this.telemetryImportResult = null;
+
+    this.telemetryService
+      .importCsv(
+        this.satellite.missionId,
+        this.satellite.id,
+        this.selectedTelemetryFile
+      )
+      .subscribe({
+        next: (result) => {
+          this.telemetryImporting = false;
+          this.telemetryImportResult = result;
+          this.telemetryImportSuccessMessage =
+            `${result.importedCount} point(s) de télémétrie importé(s) avec succès.`;
+        },
+        error: (error) => {
+          this.telemetryImporting = false;
+
+          if (error.status === 403) {
+            this.router.navigate(['/forbidden']);
+            return;
+          }
+
+          if (error.status === 400 && error.error?.errors) {
+            this.telemetryImportErrorMessage = 'Le fichier CSV contient des erreurs.';
+            this.telemetryImportErrors = error.error.errors;
+            return;
+          }
+
+          if (error.status === 404) {
+            this.telemetryImportErrorMessage = 'Satellite ou mission introuvable.';
+            return;
+          }
+
+          this.telemetryImportErrorMessage = 'Impossible d’importer le fichier de télémétrie.';
+        }
+      });
   }
 }

--- a/frontend/src/app/telemetry/models/telemetry-import.model.ts
+++ b/frontend/src/app/telemetry/models/telemetry-import.model.ts
@@ -1,0 +1,11 @@
+export interface TelemetryImportError {
+  line: number;
+  message: string;
+}
+
+export interface TelemetryImportResponse {
+  importId: string | null;
+  importedCount: number;
+  errorCount: number;
+  errors: TelemetryImportError[];
+}

--- a/frontend/src/app/telemetry/services/telemetry.service.ts
+++ b/frontend/src/app/telemetry/services/telemetry.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { TelemetryImportResponse } from '../models/telemetry-import.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TelemetryService {
+
+  private readonly apiUrl = 'http://localhost:8080/api';
+
+  constructor(private http: HttpClient) {}
+
+  importCsv(
+    missionId: number,
+    satelliteId: number,
+    file: File
+  ): Observable<TelemetryImportResponse> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    return this.http.post<TelemetryImportResponse>(
+      `${this.apiUrl}/missions/${missionId}/satellites/${satelliteId}/telemetry/import`,
+      formData
+    );
+  }
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Résumé</h2><p>Cette PR ajoute l’US15 : import de données de télémétrie au format CSV.</p><p>Elle introduit MongoDB dans le projet afin de stocker les données de télémétrie dans une base non relationnelle, séparée des données métier relationnelles stockées dans PostgreSQL.</p><p>Les données importées sont associées à une mission, à un satellite et à un identifiant d’import.</p><hr><h2>Changements principaux</h2><ul><li><p>Ajout de MongoDB dans <code inline="">docker-compose.yml</code></p></li><li><p>Ajout de la dépendance Spring Data MongoDB</p></li><li><p>Configuration MongoDB via <code inline="">spring.mongodb.uri</code></p></li><li><p>Création de la collection MongoDB <code inline="">telemetry_points</code></p></li><li><p>Création du document MongoDB <code inline="">TelemetryPoint</code></p></li><li><p>Ajout d’un index composé sur <code inline="">satelliteId</code>, <code inline="">metric</code>, <code inline="">timestamp</code></p></li><li><p>Ajout du repository Mongo <code inline="">TelemetryPointRepository</code></p></li><li><p>Ajout de l’endpoint d’import CSV : <code inline="">POST /api/missions/{missionId}/satellites/{satelliteId}/telemetry/import</code></p></li><li><p>Ajout du service d’import CSV</p></li><li><p>Validation complète du format CSV</p></li><li><p>Rejet de l’import si une ou plusieurs lignes sont invalides</p></li><li><p>Garantie qu’aucune donnée partielle n’est persistée en cas d’erreur</p></li><li><p>Gestion des erreurs CSV ligne par ligne</p></li><li><p>Support du BOM UTF-8 dans le header CSV</p></li><li><p>Ajout de l’interface frontend d’import CSV sur la page détail satellite</p></li><li><p>Affichage des messages de succès et des erreurs côté frontend</p></li><li><p>Mise à jour du <code inline="">README.md</code></p></li><li><p>Ajout de <code inline="">docs/tests/US15-tests.md</code></p></li></ul><hr><h2>Format CSV supporté</h2><p>Le fichier CSV doit contenir le header suivant :</p><p><code inline="">timestamp,metric,value</code></p><p>Exemple de fichier valide :</p><p><code inline="">2026-01-01T10:00:00Z,temperature,42.5</code></p><p><code inline="">2026-01-01T10:00:00Z,battery,78</code></p><p>Les règles de validation sont les suivantes :</p><ul><li><p><code inline="">timestamp</code> doit être au format ISO-8601</p></li><li><p><code inline="">metric</code> ne doit pas être vide</p></li><li><p><code inline="">value</code> doit être numérique</p></li><li><p>le séparateur attendu est la virgule</p></li><li><p>le header est obligatoire</p></li></ul><hr><h2>Endpoint ajouté</h2>
Méthode | Endpoint | Description | Rôles autorisés
-- | -- | -- | --
POST | /api/missions/{missionId}/satellites/{satelliteId}/telemetry/import | Importer un fichier CSV de télémétrie | ADMIN, OPERATEUR

<p>Aucune modification spécifique du <code inline="">SecurityConfig</code> n’a été nécessaire, l’endpoint étant couvert par les règles existantes sur les ressources opérationnelles.</p><hr><h2>Tests backend</h2><p>Les tests backend couvrent :</p><ul><li><p>import d’un CSV valide</p></li><li><p>persistance des points dans MongoDB</p></li><li><p>rejet d’un header invalide</p></li><li><p>rejet d’un timestamp invalide</p></li><li><p>rejet d’une métrique vide</p></li><li><p>rejet d’une valeur non numérique</p></li><li><p>support d’un header CSV avec BOM UTF-8</p></li><li><p>rejet d’un fichier vide</p></li><li><p>rejet d’un fichier non CSV</p></li><li><p>rejet d’un satellite inexistant</p></li><li><p>rejet d’un satellite inactif</p></li><li><p>rejet d’une mission clôturée</p></li><li><p>rejet d’un satellite rattaché à une autre mission</p></li><li><p>accès ADMIN autorisé</p></li><li><p>accès OPERATEUR autorisé</p></li><li><p>accès LECTEUR refusé</p></li><li><p>accès sans authentification refusé</p></li></ul><p>Résultat :</p><p><code inline="">./mvnw clean test</code></p><p><code inline="">Tests run: 180, Failures: 0, Errors: 0, Skipped: 0</code></p><p><code inline="">BUILD SUCCESS</code></p><hr><h2>Tests frontend</h2><p>Les tests manuels côté frontend couvrent :</p><ul><li><p>affichage de la section d’import CSV sur la page détail satellite</p></li><li><p>sélection d’un fichier CSV</p></li><li><p>affichage du nom du fichier sélectionné</p></li><li><p>import d’un CSV valide</p></li><li><p>message de succès après import</p></li><li><p>import d’un CSV invalide</p></li><li><p>affichage des erreurs ligne par ligne</p></li><li><p>comportement avec un rôle LECTEUR</p></li><li><p>build Angular</p></li></ul><p>Résultat :</p><p><code inline="">npm run build</code></p><p><code inline="">Application bundle generation complete</code></p><hr><h2>Validation manuelle</h2><p>Validation réalisée avec Postman :</p><ul><li><p>import CSV valide</p></li><li><p>réponse <code inline="">201 Created</code></p></li><li><p><code inline="">importedCount = 2</code></p></li><li><p><code inline="">errorCount = 0</code></p></li><li><p>import CSV invalide</p></li><li><p>réponse <code inline="">400 Bad Request</code></p></li><li><p>erreurs retournées ligne par ligne</p></li><li><p>vérification que l’import invalide ne persiste aucune donnée partielle</p></li></ul><p>Validation réalisée avec MongoDB :</p><ul><li><p>connexion via <code inline="">mongosh</code></p></li><li><p>vérification de la collection <code inline="">telemetry_points</code></p></li><li><p>présence des documents importés</p></li><li><p>présence des champs <code inline="">missionId</code>, <code inline="">satelliteId</code>, <code inline="">timestamp</code>, <code inline="">metric</code>, <code inline="">value</code>, <code inline="">sourceImportId</code>, <code inline="">createdAt</code></p></li></ul><p>Validation réalisée dans le navigateur :</p><ul><li><p>import CSV visible pour ADMIN / OPERATEUR</p></li><li><p>import non autorisé pour LECTEUR</p></li><li><p>succès affiché après import valide</p></li><li><p>erreurs affichées après import invalide</p></li></ul><hr><h2>Notes techniques</h2><ul><li><p>La configuration MongoDB utilise Spring Boot 4 avec la propriété <code inline="">spring.mongodb.uri</code></p></li><li><p>La propriété <code inline="">spring.data.mongodb.uri</code> n’est pas utilisée dans ce projet Spring Boot 4</p></li><li><p>Une méthode <code inline="">findByIdWithMission</code> a été ajoutée au repository satellite afin de charger la mission avec le satellite et éviter les erreurs <code inline="">LazyInitializationException</code></p></li><li><p>L’import CSV normalise le header afin de supporter les fichiers contenant un BOM UTF-8</p></li><li><p>L’import CSV suit une logique “tout ou rien” : si une ligne est invalide, aucune donnée n’est sauvegardée</p></li></ul><hr><h2>Hors périmètre</h2><p>Cette PR ne couvre pas encore :</p><ul><li><p>la visualisation graphique des données de télémétrie</p></li><li><p>la détection automatique d’anomalies</p></li><li><p>l’import temps réel</p></li><li><p>la modification de points existants</p></li><li><p>la suppression de points existants</p></li><li><p>l’historique détaillé des imports</p></li><li><p>la pagination ou le filtrage des points importés</p></li><li><p>l’export des données de télémétrie</p></li></ul><p>Ces sujets seront traités dans des user stories futures.</p><hr><h2>Documentation</h2><ul><li><p>Mise à jour du <code inline="">README.md</code></p></li><li><p>Ajout de <code inline="">docs/tests/US15-tests.md</code></p></li></ul><hr><h2>Conclusion</h2><p>L’US15 est terminée.</p><p>Le projet dispose maintenant d’un import CSV de télémétrie fonctionnel, sécurisé et testé.</p><p>Les données sont stockées dans MongoDB, ce qui introduit une base non relationnelle dans l’architecture du projet et prépare les prochaines fonctionnalités de visualisation et de détection d’anomalies.</p></body></html><!--EndFragment-->
</body>
</html>
- Ajout du service MongoDB `mongo:7` dans GitHub Actions pour exécuter les tests backend liés à la télémétrie.