### PR TITLE
feat(telemetry): add telemetry chart visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1609,6 +1609,212 @@ Ces éléments sont prévus dans des user stories futures.
 
 ---
 
+## Visualisation des données de télémétrie
+
+L’application permet de visualiser les données de télémétrie importées sous forme de graphiques temporels.
+
+Cette fonctionnalité permet d’analyser l’évolution des métriques d’un satellite dans le temps, comme par exemple :
+
+* la température ;
+* le niveau de batterie ;
+* la vitesse ;
+* toute autre métrique importée via CSV.
+
+Les données affichées proviennent de MongoDB, dans la collection `telemetry_points`.
+
+---
+
+### Objectif
+
+La visualisation de télémétrie permet à un utilisateur authentifié de consulter les mesures associées à un satellite et d’observer leur évolution dans le temps.
+
+Les graphiques sont en lecture seule.
+
+---
+
+### Endpoints API
+
+| Méthode | Endpoint                                          | Description                                           | Rôles autorisés           |
+| ------- | ------------------------------------------------- | ----------------------------------------------------- | ------------------------- |
+| `GET`   | `/api/satellites/{satelliteId}/telemetry/metrics` | Récupérer les métriques disponibles pour un satellite | ADMIN, OPERATEUR, LECTEUR |
+| `GET`   | `/api/satellites/{satelliteId}/telemetry`         | Récupérer les points de télémétrie filtrés            | ADMIN, OPERATEUR, LECTEUR |
+
+---
+
+### Paramètres de recherche
+
+Endpoint :
+
+`GET /api/satellites/{satelliteId}/telemetry`
+
+| Paramètre | Obligatoire | Description                                                            |
+| --------- | ----------- | ---------------------------------------------------------------------- |
+| `metric`  | Oui         | Métrique à afficher. Peut être répétée pour afficher plusieurs courbes |
+| `from`    | Non         | Date de début au format ISO-8601                                       |
+| `to`      | Non         | Date de fin au format ISO-8601                                         |
+| `limit`   | Non         | Nombre maximum de points retournés                                     |
+
+Exemple :
+
+`GET /api/satellites/3/telemetry?metric=temperature&metric=battery&limit=5000`
+
+---
+
+### Réponse API
+
+Exemple de réponse :
+
+```json
+{
+  "satelliteId": 3,
+  "metrics": [
+    "temperature",
+    "battery"
+  ],
+  "count": 4,
+  "points": [
+    {
+      "timestamp": "2026-01-01T10:00:00Z",
+      "metric": "temperature",
+      "value": 40.0
+    },
+    {
+      "timestamp": "2026-01-01T10:05:00Z",
+      "metric": "temperature",
+      "value": 42.5
+    },
+    {
+      "timestamp": "2026-01-01T10:00:00Z",
+      "metric": "battery",
+      "value": 80.0
+    },
+    {
+      "timestamp": "2026-01-01T10:05:00Z",
+      "metric": "battery",
+      "value": 78.0
+    }
+  ]
+}
+```
+
+---
+
+### Règles métier
+
+| Règle                         | Description                                                                                     |
+| ----------------------------- | ----------------------------------------------------------------------------------------------- |
+| Données existantes uniquement | Seules les données de télémétrie déjà importées sont affichées                                  |
+| Métrique obligatoire          | Au moins une métrique doit être sélectionnée                                                    |
+| Tri chronologique             | Les points sont retournés dans l’ordre chronologique                                            |
+| Filtre période                | Les paramètres `from` et `to` permettent de filtrer sur une période                             |
+| Limitation de volume          | Le nombre de points retournés est limité                                                        |
+| Lecture seule                 | Les graphiques ne modifient aucune donnée                                                       |
+| Consultation après clôture    | Les données restent consultables même si la mission est clôturée ou si le satellite est inactif |
+| Sécurité                      | ADMIN, OPERATEUR et LECTEUR peuvent consulter                                                   |
+
+---
+
+### Frontend
+
+La page détail satellite affiche une section de visualisation de télémétrie.
+
+Cette section permet :
+
+* d’afficher les métriques disponibles ;
+* de sélectionner une ou plusieurs métriques ;
+* de filtrer par période ;
+* de rafraîchir les données à la demande ;
+* d’afficher les données sous forme de courbes temporelles ;
+* d’afficher les états vide, chargement et erreur.
+
+Les graphiques utilisent :
+
+* l’axe horizontal pour le temps ;
+* l’axe vertical pour la valeur de la métrique ;
+* une courbe par métrique sélectionnée.
+
+---
+
+### Tests réalisés
+
+Les tests backend couvrent :
+
+* la récupération des métriques disponibles ;
+* la lecture des données pour une métrique ;
+* la lecture de plusieurs métriques ;
+* le filtrage par période ;
+* le tri chronologique ;
+* la limitation du nombre de points ;
+* le rejet d’une requête sans métrique ;
+* le rejet d’une période invalide ;
+* le rejet d’un satellite inexistant ;
+* l’accès ADMIN ;
+* l’accès OPERATEUR ;
+* l’accès LECTEUR ;
+* le refus d’un utilisateur non authentifié.
+
+Résultat backend :
+
+```text
+Tests run: 196, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+Le build frontend a également été validé :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+### Validation fonctionnelle
+
+La fonctionnalité a été validée dans le navigateur avec un fichier CSV de démonstration contenant 15 points de télémétrie.
+
+Cas validés :
+
+* import de données de télémétrie ;
+* détection automatique des métriques disponibles ;
+* affichage des métriques `battery`, `speed`, `temperature` ;
+* affichage d’une courbe par métrique ;
+* affichage de plusieurs métriques en même temps ;
+* filtrage par période ;
+* rafraîchissement manuel ;
+* consultation en lecture seule.
+
+---
+
+### Limites actuelles
+
+L’US16 ne couvre pas encore :
+
+* la visualisation temps réel ;
+* l’analyse statistique avancée ;
+* la personnalisation avancée des graphiques ;
+* les axes indépendants par métrique ;
+* la normalisation automatique des courbes ;
+* le zoom sur une période ;
+* l’export du graphique.
+
+Lorsque des métriques ont des ordres de grandeur très différents, par exemple `speed` autour de 7600 et `temperature` autour de 40, la courbe de plus grande valeur peut écraser visuellement les autres courbes.
+
+---
+
+### Perspectives d’évolution
+
+Évolutions possibles :
+
+* ajouter un axe vertical par métrique ;
+* normaliser les courbes pour comparer les tendances ;
+* ajouter un zoom temporel ;
+* afficher les valeurs min, max et moyenne ;
+* ajouter des seuils visuels ;
+* préparer la détection d’anomalies ;
+* ajouter un export CSV ou PDF des données affichées.
+
+---
+
 ## Dashboard mission
 
 L’application permet de consulter un dashboard synthétique pour une mission.

--- a/backend/src/main/java/com/finalspace/backend/telemetry/controller/TelemetryController.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/controller/TelemetryController.java
@@ -1,11 +1,16 @@
 package com.finalspace.backend.telemetry.controller;
 
 import com.finalspace.backend.telemetry.dto.TelemetryImportResponse;
+import com.finalspace.backend.telemetry.dto.TelemetryQueryResponse;
+import com.finalspace.backend.telemetry.service.TelemetryQueryService;
 import com.finalspace.backend.telemetry.service.TelemetryImportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.Instant;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class TelemetryController {
 
     private final TelemetryImportService telemetryImportService;
+    private final TelemetryQueryService telemetryQueryService;
 
     @PostMapping("/missions/{missionId}/satellites/{satelliteId}/telemetry/import")
     @ResponseStatus(HttpStatus.CREATED)
@@ -22,5 +28,29 @@ public class TelemetryController {
             @RequestParam("file") MultipartFile file
     ) {
         return telemetryImportService.importCsv(missionId, satelliteId, file);
+    }
+
+    @GetMapping("/satellites/{satelliteId}/telemetry/metrics")
+    public List<String> getTelemetryMetrics(
+            @PathVariable Long satelliteId
+    ) {
+        return telemetryQueryService.getAvailableMetrics(satelliteId);
+    }
+
+    @GetMapping("/satellites/{satelliteId}/telemetry")
+    public TelemetryQueryResponse getTelemetry(
+            @PathVariable Long satelliteId,
+            @RequestParam(value = "metric", required = false) List<String> metrics,
+            @RequestParam(value = "from", required = false) Instant from,
+            @RequestParam(value = "to", required = false) Instant to,
+            @RequestParam(value = "limit", required = false) Integer limit
+    ) {
+        return telemetryQueryService.getTelemetry(
+                satelliteId,
+                metrics,
+                from,
+                to,
+                limit
+        );
     }
 }

--- a/backend/src/main/java/com/finalspace/backend/telemetry/dto/TelemetryPointResponse.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/dto/TelemetryPointResponse.java
@@ -1,0 +1,10 @@
+package com.finalspace.backend.telemetry.dto;
+
+import java.time.Instant;
+
+public record TelemetryPointResponse(
+        Instant timestamp,
+        String metric,
+        Double value
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/dto/TelemetryQueryResponse.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/dto/TelemetryQueryResponse.java
@@ -1,0 +1,11 @@
+package com.finalspace.backend.telemetry.dto;
+
+import java.util.List;
+
+public record TelemetryQueryResponse(
+        Long satelliteId,
+        List<String> metrics,
+        int count,
+        List<TelemetryPointResponse> points
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/service/TelemetryQueryService.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/service/TelemetryQueryService.java
@@ -1,0 +1,19 @@
+package com.finalspace.backend.telemetry.service;
+
+import com.finalspace.backend.telemetry.dto.TelemetryQueryResponse;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface TelemetryQueryService {
+
+    List<String> getAvailableMetrics(Long satelliteId);
+
+    TelemetryQueryResponse getTelemetry(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to,
+            Integer limit
+    );
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/service/impl/TelemetryQueryServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/service/impl/TelemetryQueryServiceImpl.java
@@ -1,0 +1,147 @@
+package com.finalspace.backend.telemetry.service.impl;
+
+import com.finalspace.backend.common.exception.BusinessException;
+import com.finalspace.backend.common.exception.ResourceNotFoundException;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.telemetry.TelemetryPoint;
+import com.finalspace.backend.telemetry.dto.TelemetryPointResponse;
+import com.finalspace.backend.telemetry.dto.TelemetryQueryResponse;
+import com.finalspace.backend.telemetry.service.TelemetryQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TelemetryQueryServiceImpl implements TelemetryQueryService {
+
+    private static final int DEFAULT_LIMIT = 5000;
+    private static final int MAX_LIMIT = 5000;
+
+    private final SatelliteRepository satelliteRepository;
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public List<String> getAvailableMetrics(Long satelliteId) {
+        validateSatelliteExists(satelliteId);
+
+        Query query = Query.query(Criteria.where("satelliteId").is(satelliteId));
+
+        return mongoTemplate
+                .findDistinct(
+                        query,
+                        "metric",
+                        TelemetryPoint.class,
+                        String.class
+                )
+                .stream()
+                .sorted()
+                .toList();
+    }
+
+    @Override
+    public TelemetryQueryResponse getTelemetry(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to,
+            Integer limit
+    ) {
+        validateSatelliteExists(satelliteId);
+
+        List<String> normalizedMetrics = normalizeMetrics(metrics);
+        validatePeriod(from, to);
+
+        int resolvedLimit = resolveLimit(limit);
+
+        Query query = new Query();
+
+        query.addCriteria(
+                Criteria.where("satelliteId").is(satelliteId)
+                        .and("metric").in(normalizedMetrics)
+        );
+
+        if (from != null || to != null) {
+            Criteria timestampCriteria = Criteria.where("timestamp");
+
+            if (from != null) {
+                timestampCriteria = timestampCriteria.gte(from);
+            }
+
+            if (to != null) {
+                timestampCriteria = timestampCriteria.lte(to);
+            }
+
+            query.addCriteria(timestampCriteria);
+        }
+
+        query.with(Sort.by(Sort.Direction.ASC, "timestamp"));
+        query.limit(resolvedLimit);
+
+        List<TelemetryPointResponse> points = mongoTemplate.find(query, TelemetryPoint.class)
+                .stream()
+                .map(point -> new TelemetryPointResponse(
+                        point.getTimestamp(),
+                        point.getMetric(),
+                        point.getValue()
+                ))
+                .toList();
+
+        return new TelemetryQueryResponse(
+                satelliteId,
+                normalizedMetrics,
+                points.size(),
+                points
+        );
+    }
+
+    private void validateSatelliteExists(Long satelliteId) {
+        if (!satelliteRepository.existsById(satelliteId)) {
+            throw new ResourceNotFoundException("Satellite introuvable");
+        }
+    }
+
+    private List<String> normalizeMetrics(List<String> metrics) {
+        if (metrics == null || metrics.isEmpty()) {
+            throw new BusinessException("Au moins une métrique est obligatoire");
+        }
+
+        List<String> normalizedMetrics = metrics.stream()
+                .flatMap(metric -> Arrays.stream(metric.split(",")))
+                .map(String::trim)
+                .filter(metric -> !metric.isBlank())
+                .distinct()
+                .toList();
+
+        if (normalizedMetrics.isEmpty()) {
+            throw new BusinessException("Au moins une métrique est obligatoire");
+        }
+
+        return normalizedMetrics;
+    }
+
+    private void validatePeriod(Instant from, Instant to) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new BusinessException("La date de début doit être antérieure à la date de fin");
+        }
+    }
+
+    private int resolveLimit(Integer limit) {
+        if (limit == null) {
+            return DEFAULT_LIMIT;
+        }
+
+        if (limit < 1) {
+            throw new BusinessException("La limite doit être supérieure à 0");
+        }
+
+        return Math.min(limit, MAX_LIMIT);
+    }
+}

--- a/backend/src/test/java/com/finalspace/backend/security/TelemetryQueryAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/finalspace/backend/security/TelemetryQueryAuthorizationIntegrationTest.java
@@ -1,0 +1,267 @@
+package com.finalspace.backend.security;
+
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.mission.MissionRepository;
+import com.finalspace.backend.mission.MissionStatus;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.satellite.SatelliteStatus;
+import com.finalspace.backend.telemetry.TelemetryPoint;
+import com.finalspace.backend.telemetry.TelemetryPointRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TelemetryQueryAuthorizationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private SatelliteRepository satelliteRepository;
+
+    @Autowired
+    private TelemetryPointRepository telemetryPointRepository;
+
+    private final JsonMapper jsonMapper = new JsonMapper();
+
+    @BeforeEach
+    void cleanDatabase() {
+        telemetryPointRepository.deleteAll();
+        satelliteRepository.deleteAll();
+        missionRepository.deleteAll();
+    }
+
+    @Test
+    void adminShouldReadTelemetryMetrics() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/metrics", satellite.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0]").value("battery"))
+                .andExpect(jsonPath("$[1]").value("temperature"));
+    }
+
+    @Test
+    void operatorShouldReadTelemetry() throws Exception {
+        String token = loginAndGetToken("operator@finalspace.com", "operator123");
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", satellite.getId())
+                        .param("metric", "temperature")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.satelliteId").value(satellite.getId()))
+                .andExpect(jsonPath("$.metrics[0]").value("temperature"))
+                .andExpect(jsonPath("$.count").value(3))
+                .andExpect(jsonPath("$.points[0].metric").value("temperature"))
+                .andExpect(jsonPath("$.points[0].value").value(40.0))
+                .andExpect(jsonPath("$.points[1].value").value(42.5))
+                .andExpect(jsonPath("$.points[2].value").value(45.0));
+    }
+
+    @Test
+    void readerShouldReadTelemetry() throws Exception {
+        String token = loginAndGetToken("reader@finalspace.com", "reader123");
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", satellite.getId())
+                        .param("metric", "battery")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.satelliteId").value(satellite.getId()))
+                .andExpect(jsonPath("$.metrics[0]").value("battery"))
+                .andExpect(jsonPath("$.count").value(2))
+                .andExpect(jsonPath("$.points[0].metric").value("battery"))
+                .andExpect(jsonPath("$.points[1].metric").value("battery"));
+    }
+
+    @Test
+    void unauthenticatedUserShouldNotReadTelemetry() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", satellite.getId())
+                        .param("metric", "temperature"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldRejectTelemetryQueryWithoutMetric() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", satellite.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldFilterTelemetryByPeriod() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("from", "2026-01-01T10:05:00Z")
+                        .param("to", "2026-01-01T10:10:00Z")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(2))
+                .andExpect(jsonPath("$.points[0].value").value(42.5))
+                .andExpect(jsonPath("$.points[1].value").value(45.0));
+    }
+
+    @Test
+    void shouldReadMultipleMetrics() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("metric", "battery")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(5))
+                .andExpect(jsonPath("$.metrics[0]").value("temperature"))
+                .andExpect(jsonPath("$.metrics[1]").value("battery"));
+    }
+
+    @Test
+    void shouldApplyLimit() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("limit", "2")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(2))
+                .andExpect(jsonPath("$.points.length()").value(2));
+    }
+
+    @Test
+    void shouldRejectInvalidPeriod() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createSatelliteWithTelemetry();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("from", "2026-01-02T00:00:00Z")
+                        .param("to", "2026-01-01T00:00:00Z")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldRejectUnknownSatellite() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry", 99999L)
+                        .param("metric", "temperature")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    private String loginAndGetToken(String email, String password) throws Exception {
+        String request = """
+                {
+                  "email": "%s",
+                  "password": "%s"
+                }
+                """.formatted(email, password);
+
+        String response = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode responseJson = jsonMapper.readTree(response);
+
+        return responseJson.get("token").asString();
+    }
+
+    private Satellite createSatelliteWithTelemetry() {
+        Mission mission = Mission.builder()
+                .name("Mission Telemetry Charts")
+                .description("Mission utilisée pour les tests de visualisation télémétrie")
+                .status(MissionStatus.CLOTUREE)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Mission savedMission = missionRepository.save(mission);
+
+        Satellite satellite = Satellite.builder()
+                .name("TelemetryChartSat")
+                .status(SatelliteStatus.INACTIF)
+                .massKg(850.0)
+                .altitudeKm(500.0)
+                .inclinationDeg(95.0)
+                .eccentricity(0.4)
+                .mission(savedMission)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        Satellite savedSatellite = satelliteRepository.save(satellite);
+
+        String importId = UUID.randomUUID().toString();
+
+        telemetryPointRepository.saveAll(List.of(
+                createPoint(savedMission.getId(), savedSatellite.getId(), "2026-01-01T10:00:00Z", "temperature", 40.0, importId),
+                createPoint(savedMission.getId(), savedSatellite.getId(), "2026-01-01T10:05:00Z", "temperature", 42.5, importId),
+                createPoint(savedMission.getId(), savedSatellite.getId(), "2026-01-01T10:10:00Z", "temperature", 45.0, importId),
+                createPoint(savedMission.getId(), savedSatellite.getId(), "2026-01-01T10:00:00Z", "battery", 80.0, importId),
+                createPoint(savedMission.getId(), savedSatellite.getId(), "2026-01-01T10:10:00Z", "battery", 76.0, importId)
+        ));
+
+        return savedSatellite;
+    }
+
+    private TelemetryPoint createPoint(
+            Long missionId,
+            Long satelliteId,
+            String timestamp,
+            String metric,
+            Double value,
+            String importId
+    ) {
+        return TelemetryPoint.builder()
+                .missionId(missionId)
+                .satelliteId(satelliteId)
+                .timestamp(Instant.parse(timestamp))
+                .metric(metric)
+                .value(value)
+                .sourceImportId(importId)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/docs/tests/US16-tests.md
+++ b/docs/tests/US16-tests.md
@@ -1,0 +1,239 @@
+# US16 - Visualiser la télémétrie sous forme de graphiques
+
+## État de validation
+
+**US16 validée côté backend et frontend.**
+
+L’application permet de visualiser les données de télémétrie importées pour un satellite sous forme de graphiques temporels.
+
+Les données affichées proviennent de MongoDB, dans la collection `telemetry_points`.
+
+---
+
+## Objectif de l’US
+
+Permettre à un utilisateur authentifié de consulter les données de télémétrie d’un satellite afin d’analyser l’évolution de ses paramètres dans le temps.
+
+Les graphiques permettent de visualiser des séries temporelles comme :
+
+* température ;
+* batterie ;
+* vitesse ;
+* autres métriques importées.
+
+---
+
+## Dépendances
+
+| User Story | Description                                             | État    |
+| ---------- | ------------------------------------------------------- | ------- |
+| US15       | Import des données de télémétrie au format CSV          | Validée |
+| US16       | Visualisation de la télémétrie sous forme de graphiques | Validée |
+
+---
+
+## Endpoints testés
+
+| Méthode | Endpoint                                          | Description                                |
+| ------- | ------------------------------------------------- | ------------------------------------------ |
+| `GET`   | `/api/satellites/{satelliteId}/telemetry/metrics` | Récupérer les métriques disponibles        |
+| `GET`   | `/api/satellites/{satelliteId}/telemetry`         | Récupérer les points de télémétrie filtrés |
+
+---
+
+## Paramètres de recherche
+
+| Paramètre | Obligatoire | Description                           |
+| --------- | ----------- | ------------------------------------- |
+| `metric`  | Oui         | Une ou plusieurs métriques à afficher |
+| `from`    | Non         | Date de début au format ISO-8601      |
+| `to`      | Non         | Date de fin au format ISO-8601        |
+| `limit`   | Non         | Limite du nombre de points retournés  |
+
+---
+
+## Règles métier couvertes
+
+| Référence     | Règle                                                        | État |
+| ------------- | ------------------------------------------------------------ | ---- |
+| RG-TEL-VIS-01 | Les métriques disponibles peuvent être récupérées            | PASS |
+| RG-TEL-VIS-02 | Une métrique est obligatoire pour consulter les points       | PASS |
+| RG-TEL-VIS-03 | Plusieurs métriques peuvent être consultées simultanément    | PASS |
+| RG-TEL-VIS-04 | Les données sont retournées dans l’ordre chronologique       | PASS |
+| RG-TEL-VIS-05 | Le filtre `from` / `to` est appliqué                         | PASS |
+| RG-TEL-VIS-06 | Une période invalide est rejetée                             | PASS |
+| RG-TEL-VIS-07 | Une limite de volume est appliquée                           | PASS |
+| RG-TEL-VIS-08 | Un satellite inexistant est rejeté                           | PASS |
+| RG-TEL-VIS-09 | Les données restent consultables si la mission est clôturée  | PASS |
+| RG-TEL-VIS-10 | Les données restent consultables si le satellite est inactif | PASS |
+| RG-TEL-VIS-11 | ADMIN peut consulter                                         | PASS |
+| RG-TEL-VIS-12 | OPERATEUR peut consulter                                     | PASS |
+| RG-TEL-VIS-13 | LECTEUR peut consulter                                       | PASS |
+| RG-TEL-VIS-14 | Un utilisateur non authentifié ne peut pas consulter         | PASS |
+
+---
+
+## Tests d’intégration API / sécurité
+
+Classe associée :
+
+```text
+backend/src/test/java/com/finalspace/backend/security/TelemetryQueryAuthorizationIntegrationTest.java
+```
+
+| ID       | Scénario                                           | Résultat attendu                   | État |
+| -------- | -------------------------------------------------- | ---------------------------------- | ---- |
+| US16-T01 | ADMIN récupère les métriques disponibles           | `200 OK`                           | PASS |
+| US16-T02 | OPERATEUR consulte une métrique                    | `200 OK`                           | PASS |
+| US16-T03 | LECTEUR consulte une métrique                      | `200 OK`                           | PASS |
+| US16-T04 | Utilisateur non authentifié consulte la télémétrie | `401 Unauthorized`                 | PASS |
+| US16-T05 | Requête sans métrique                              | `400 Bad Request`                  | PASS |
+| US16-T06 | Filtre par période                                 | Données filtrées                   | PASS |
+| US16-T07 | Lecture de plusieurs métriques                     | Données multi-métriques retournées | PASS |
+| US16-T08 | Limite de volume                                   | Nombre de points limité            | PASS |
+| US16-T09 | Période invalide                                   | `400 Bad Request`                  | PASS |
+| US16-T10 | Satellite inexistant                               | `404 Not Found`                    | PASS |
+
+---
+
+## Tests frontend réalisés
+
+| ID       | Scénario                            | Résultat attendu                                 | État |
+| -------- | ----------------------------------- | ------------------------------------------------ | ---- |
+| US16-T11 | Affichage des métriques disponibles | Métriques affichées sous forme de cases à cocher | PASS |
+| US16-T12 | Sélection d’une métrique            | Une courbe est affichée                          | PASS |
+| US16-T13 | Sélection de plusieurs métriques    | Plusieurs courbes sont affichées                 | PASS |
+| US16-T14 | Rafraîchissement manuel             | Les données sont rechargées                      | PASS |
+| US16-T15 | Filtrage par période                | Le graphique se met à jour selon les dates       | PASS |
+| US16-T16 | Aucune donnée disponible            | Message informatif affiché                       | PASS |
+| US16-T17 | Données importées après US15        | Les métriques sont rechargées après import       | PASS |
+| US16-T18 | Build Angular                       | Build OK                                         | PASS |
+
+---
+
+## Données de test utilisées
+
+Un fichier CSV de démonstration a été importé pour tester l’affichage graphique.
+
+Métriques utilisées :
+
+* `temperature`
+* `battery`
+* `speed`
+
+Nombre de points importés :
+
+```text
+15
+```
+
+Résultat attendu :
+
+* 5 points pour `temperature` ;
+* 5 points pour `battery` ;
+* 5 points pour `speed`.
+
+---
+
+## Résultat d’exécution automatisée
+
+Commande backend :
+
+```bash
+./mvnw test
+```
+
+Résultat :
+
+```text
+Tests run: 196, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+Commande frontend :
+
+```bash
+npm run build
+```
+
+Résultat :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+## Validation navigateur
+
+La fonctionnalité a été testée depuis la page détail satellite.
+
+Cas validés :
+
+* métriques disponibles affichées ;
+* graphique affiché après clic sur `Rafraîchir` ;
+* affichage de la métrique `battery` ;
+* affichage de la métrique `speed` ;
+* affichage de la métrique `temperature` ;
+* affichage de plusieurs métriques simultanément ;
+* affichage du nombre de points ;
+* affichage du nombre de métriques sélectionnées ;
+* filtrage avec dates de début et de fin ;
+* lecture seule des graphiques.
+
+---
+
+## Notes techniques
+
+Les courbes sont générées côté Angular avec un SVG simple.
+
+Aucune dépendance graphique externe n’a été ajoutée.
+
+Les données sont transformées côté frontend afin de produire :
+
+* une série par métrique ;
+* des points SVG ;
+* un chemin SVG pour chaque courbe.
+
+---
+
+## Limites identifiées
+
+Lorsque plusieurs métriques ont des ordres de grandeur très différents, la métrique avec les valeurs les plus élevées peut écraser visuellement les autres.
+
+Exemple :
+
+* `speed` autour de 7600 ;
+* `battery` autour de 70 ;
+* `temperature` autour de 40.
+
+Cette limite est acceptable pour l’US16, mais pourra être améliorée dans une évolution future avec :
+
+* une normalisation des courbes ;
+* un axe par métrique ;
+* un affichage métrique par métrique ;
+* des statistiques dédiées.
+
+---
+
+## Hors périmètre
+
+L’US16 ne couvre pas :
+
+* la visualisation temps réel ;
+* la détection automatique d’anomalies ;
+* les seuils d’alerte ;
+* les statistiques avancées ;
+* le zoom graphique ;
+* l’export du graphique ;
+* la personnalisation avancée des courbes.
+
+---
+
+## Conclusion
+
+L’US16 est terminée.
+
+Les utilisateurs authentifiés peuvent consulter les données de télémétrie d’un satellite sous forme de graphiques temporels.
+
+La fonctionnalité prépare les prochaines user stories liées à l’analyse et à la détection d’anomalies.

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.css
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.css
@@ -584,3 +584,130 @@ input:focus {
   color: #bbf7d0;
   font-size: 18px;
 }
+
+.telemetry-chart-section {
+  margin-top: 32px;
+  padding: 24px;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.telemetry-filter-card {
+  margin-top: 20px;
+  padding: 18px;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.62);
+}
+
+.telemetry-metric-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.telemetry-metric-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  border-radius: 999px;
+  color: #e0f2fe;
+  background: rgba(2, 132, 199, 0.14);
+  cursor: pointer;
+  user-select: none;
+}
+
+.telemetry-metric-item input {
+  width: 16px;
+  height: 16px;
+  accent-color: #38bdf8;
+}
+
+.telemetry-metric-item span {
+  font-weight: 700;
+}
+
+.telemetry-period-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.telemetry-chart-card {
+  margin-top: 20px;
+  padding: 18px;
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.68);
+}
+
+.telemetry-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.telemetry-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #e2e8f0;
+}
+
+.telemetry-legend-color {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  box-shadow: 0 0 14px rgba(56, 189, 248, 0.35);
+}
+
+.telemetry-chart-wrapper {
+  overflow-x: auto;
+  padding: 12px;
+  border: 1px solid rgba(51, 65, 85, 0.9);
+  border-radius: 14px;
+  background: radial-gradient(circle at top, rgba(30, 41, 59, 0.9), rgba(2, 6, 23, 0.92));
+}
+
+.telemetry-chart {
+  width: 100%;
+  min-width: 760px;
+  height: auto;
+}
+
+.telemetry-axis {
+  stroke: rgba(148, 163, 184, 0.55);
+  stroke-width: 2;
+}
+
+.telemetry-chart path {
+  filter: drop-shadow(0 0 5px rgba(56, 189, 248, 0.22));
+}
+
+.telemetry-chart circle {
+  cursor: pointer;
+}
+
+.telemetry-chart-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+  color: #cbd5e1;
+  font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  .telemetry-period-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .telemetry-chart-summary {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.html
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.html
@@ -602,6 +602,143 @@
         </div>
       </div>
     </section>
+    <section class="telemetry-chart-section">
+      <div class="simulation-header">
+        <div>
+          <h2>Visualisation de la télémétrie</h2>
+          <p>
+            Affiche les données de télémétrie importées sous forme de courbes temporelles.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          class="secondary-button"
+          (click)="refreshTelemetryChart()"
+          [disabled]="telemetryLoading || availableTelemetryMetrics.length === 0"
+        >
+          {{ telemetryLoading ? 'Chargement...' : 'Rafraîchir' }}
+        </button>
+      </div>
+
+      <div *ngIf="availableTelemetryMetrics.length === 0 && !telemetryLoading" class="info-card">
+        Aucune métrique de télémétrie disponible pour ce satellite.
+      </div>
+
+      <div *ngIf="availableTelemetryMetrics.length > 0" class="telemetry-filter-card">
+        <div class="telemetry-metric-list">
+          <label
+            *ngFor="let metric of availableTelemetryMetrics"
+            class="telemetry-metric-item"
+          >
+            <input
+              type="checkbox"
+              [checked]="isTelemetryMetricSelected(metric)"
+              (change)="onTelemetryMetricToggle(metric, $event)"
+            />
+            <span>{{ metric }}</span>
+          </label>
+        </div>
+
+        <div class="telemetry-period-grid">
+          <div class="form-group">
+            <label for="telemetryFrom">Début</label>
+            <input
+              id="telemetryFrom"
+              type="datetime-local"
+              [(ngModel)]="telemetryFrom"
+              name="telemetryFrom"
+            />
+          </div>
+
+          <div class="form-group">
+            <label for="telemetryTo">Fin</label>
+            <input
+              id="telemetryTo"
+              type="datetime-local"
+              [(ngModel)]="telemetryTo"
+              name="telemetryTo"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div *ngIf="telemetryErrorMessage" class="error-card">
+        {{ telemetryErrorMessage }}
+      </div>
+
+      <div *ngIf="telemetryEmptyMessage && telemetryChartSeries.length === 0" class="info-card">
+        {{ telemetryEmptyMessage }}
+      </div>
+
+      <div *ngIf="telemetryChartSeries.length > 0" class="telemetry-chart-card">
+        <div class="telemetry-chart-legend">
+          <div
+            *ngFor="let series of telemetryChartSeries; let index = index"
+            class="telemetry-legend-item"
+          >
+        <span
+          class="telemetry-legend-color"
+          [style.background]="getTelemetrySeriesStroke(index)"
+        ></span>
+            <strong>{{ series.metric }}</strong>
+          </div>
+        </div>
+
+        <div class="telemetry-chart-wrapper">
+          <svg
+            class="telemetry-chart"
+            [attr.viewBox]="'0 0 ' + telemetryChartWidth + ' ' + telemetryChartHeight"
+            role="img"
+            aria-label="Graphique de télémétrie"
+          >
+            <line
+              [attr.x1]="telemetryChartPadding"
+              [attr.y1]="telemetryChartHeight - telemetryChartPadding"
+              [attr.x2]="telemetryChartWidth - telemetryChartPadding"
+              [attr.y2]="telemetryChartHeight - telemetryChartPadding"
+              class="telemetry-axis"
+            ></line>
+
+            <line
+              [attr.x1]="telemetryChartPadding"
+              [attr.y1]="telemetryChartPadding"
+              [attr.x2]="telemetryChartPadding"
+              [attr.y2]="telemetryChartHeight - telemetryChartPadding"
+              class="telemetry-axis"
+            ></line>
+
+            <g *ngFor="let series of telemetryChartSeries; let index = index">
+              <path
+                [attr.d]="series.path"
+                fill="none"
+                [attr.stroke]="getTelemetrySeriesStroke(index)"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              ></path>
+
+              <circle
+                *ngFor="let point of series.points"
+                [attr.cx]="point.x"
+                [attr.cy]="point.y"
+                r="4"
+                [attr.fill]="getTelemetrySeriesStroke(index)"
+              >
+                <title>
+                  {{ series.metric }} — {{ point.value }} — {{ point.timestamp }}
+                </title>
+              </circle>
+            </g>
+          </svg>
+        </div>
+
+        <div class="telemetry-chart-summary">
+          <span>{{ telemetryPoints.length }} point(s) affiché(s)</span>
+          <span>{{ selectedTelemetryMetrics.length }} métrique(s) sélectionnée(s)</span>
+        </div>
+      </div>
+    </section>
     <section class="simulation-history-section">
       <div class="simulation-header">
         <div>

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.ts
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.ts
@@ -17,6 +17,20 @@ import {
   TelemetryImportError,
   TelemetryImportResponse
 } from '../../telemetry/models/telemetry-import.model';
+import { TelemetryPoint } from '../../telemetry/models/telemetry-query.model';
+
+interface TelemetryChartPoint {
+  x: number;
+  y: number;
+  timestamp: string;
+  value: number;
+}
+
+interface TelemetryChartSeries {
+  metric: string;
+  path: string;
+  points: TelemetryChartPoint[];
+}
 
 @Component({
   selector: 'app-satellite-detail',
@@ -63,6 +77,22 @@ export class SatelliteDetailComponent implements OnInit {
   telemetryImportErrors: TelemetryImportError[] = [];
   telemetryImportResult: TelemetryImportResponse | null = null;
 
+  availableTelemetryMetrics: string[] = [];
+  selectedTelemetryMetrics: string[] = [];
+
+  telemetryFrom = '';
+  telemetryTo = '';
+
+  telemetryLoading = false;
+  telemetryErrorMessage = '';
+  telemetryEmptyMessage = '';
+  telemetryPoints: TelemetryPoint[] = [];
+  telemetryChartSeries: TelemetryChartSeries[] = [];
+
+  readonly telemetryChartWidth = 900;
+  readonly telemetryChartHeight = 320;
+  readonly telemetryChartPadding = 48;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -91,6 +121,7 @@ export class SatelliteDetailComponent implements OnInit {
     this.satelliteService.findById(id).subscribe({
       next: (satellite) => {
         this.satellite = satellite;
+        this.loadTelemetryMetrics();
         this.editName = satellite.name;
         this.editMassKg = satellite.massKg ?? null;
         this.editAltitudeKm = satellite.altitudeKm ?? null;
@@ -556,6 +587,9 @@ export class SatelliteDetailComponent implements OnInit {
           this.telemetryImportResult = result;
           this.telemetryImportSuccessMessage =
             `${result.importedCount} point(s) de télémétrie importé(s) avec succès.`;
+
+          this.selectedTelemetryFile = null;
+          this.loadTelemetryMetrics();
         },
         error: (error) => {
           this.telemetryImporting = false;
@@ -579,5 +613,216 @@ export class SatelliteDetailComponent implements OnInit {
           this.telemetryImportErrorMessage = 'Impossible d’importer le fichier de télémétrie.';
         }
       });
+  }
+
+  loadTelemetryMetrics(): void {
+    if (!this.satellite) {
+      return;
+    }
+
+    this.telemetryErrorMessage = '';
+    this.telemetryEmptyMessage = '';
+
+    this.telemetryService.getAvailableMetrics(this.satellite.id).subscribe({
+      next: (metrics) => {
+        this.availableTelemetryMetrics = metrics;
+        this.selectedTelemetryMetrics = metrics.length > 0 ? [metrics[0]] : [];
+
+        if (metrics.length === 0) {
+          this.telemetryEmptyMessage = 'Aucune donnée de télémétrie disponible pour ce satellite.';
+          this.telemetryPoints = [];
+          this.telemetryChartSeries = [];
+        }
+      },
+      error: (error) => {
+        if (error.status === 403) {
+          this.router.navigate(['/forbidden']);
+          return;
+        }
+
+        this.telemetryErrorMessage = 'Impossible de charger les métriques de télémétrie.';
+      }
+    });
+  }
+
+  onTelemetryMetricToggle(metric: string, event: Event): void {
+    const input = event.target as HTMLInputElement;
+
+    if (input.checked) {
+      this.selectedTelemetryMetrics = [
+        ...this.selectedTelemetryMetrics,
+        metric
+      ];
+      return;
+    }
+
+    this.selectedTelemetryMetrics = this.selectedTelemetryMetrics.filter(
+      (selectedMetric) => selectedMetric !== metric
+    );
+  }
+
+  isTelemetryMetricSelected(metric: string): boolean {
+    return this.selectedTelemetryMetrics.includes(metric);
+  }
+
+  refreshTelemetryChart(): void {
+    if (!this.satellite) {
+      return;
+    }
+
+    if (this.selectedTelemetryMetrics.length === 0) {
+      this.telemetryErrorMessage = 'Sélectionne au moins une métrique à afficher.';
+      this.telemetryEmptyMessage = '';
+      this.telemetryPoints = [];
+      this.telemetryChartSeries = [];
+      return;
+    }
+
+    const fromIso = this.toIsoDateOrNull(this.telemetryFrom);
+    const toIso = this.toIsoDateOrNull(this.telemetryTo);
+
+    this.telemetryLoading = true;
+    this.telemetryErrorMessage = '';
+    this.telemetryEmptyMessage = '';
+    this.telemetryPoints = [];
+    this.telemetryChartSeries = [];
+
+    this.telemetryService
+      .getTelemetry(
+        this.satellite.id,
+        this.selectedTelemetryMetrics,
+        fromIso,
+        toIso
+      )
+      .subscribe({
+        next: (response) => {
+          this.telemetryLoading = false;
+          this.telemetryPoints = response.points;
+          this.telemetryChartSeries = this.buildTelemetryChartSeries(response.points);
+
+          if (response.points.length === 0) {
+            this.telemetryEmptyMessage = 'Aucune donnée ne correspond aux filtres sélectionnés.';
+          }
+        },
+        error: (error) => {
+          this.telemetryLoading = false;
+
+          if (error.status === 403) {
+            this.router.navigate(['/forbidden']);
+            return;
+          }
+
+          if (error.status === 400) {
+            this.telemetryErrorMessage = 'Les filtres de télémétrie sont invalides.';
+            return;
+          }
+
+          if (error.status === 404) {
+            this.telemetryErrorMessage = 'Satellite introuvable.';
+            return;
+          }
+
+          this.telemetryErrorMessage = 'Impossible de charger les données de télémétrie.';
+        }
+      });
+  }
+
+  private buildTelemetryChartSeries(points: TelemetryPoint[]): TelemetryChartSeries[] {
+    if (points.length === 0) {
+      return [];
+    }
+
+    const timestamps = points.map((point) => new Date(point.timestamp).getTime());
+    const values = points.map((point) => point.value);
+
+    const minTime = Math.min(...timestamps);
+    const maxTime = Math.max(...timestamps);
+    const minValue = Math.min(...values);
+    const maxValue = Math.max(...values);
+
+    const groupedByMetric = new Map<string, TelemetryPoint[]>();
+
+    points.forEach((point) => {
+      const metricPoints = groupedByMetric.get(point.metric) ?? [];
+      metricPoints.push(point);
+      groupedByMetric.set(point.metric, metricPoints);
+    });
+
+    return Array.from(groupedByMetric.entries()).map(([metric, metricPoints]) => {
+      const chartPoints = metricPoints
+        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+        .map((point) => {
+          const time = new Date(point.timestamp).getTime();
+
+          return {
+            x: this.scaleValue(
+              time,
+              minTime,
+              maxTime,
+              this.telemetryChartPadding,
+              this.telemetryChartWidth - this.telemetryChartPadding
+            ),
+            y: this.scaleValue(
+              point.value,
+              minValue,
+              maxValue,
+              this.telemetryChartHeight - this.telemetryChartPadding,
+              this.telemetryChartPadding
+            ),
+            timestamp: point.timestamp,
+            value: point.value
+          };
+        });
+
+      return {
+        metric,
+        points: chartPoints,
+        path: this.buildSvgPath(chartPoints)
+      };
+    });
+  }
+
+  private buildSvgPath(points: TelemetryChartPoint[]): string {
+    return points
+      .map((point, index) => {
+        const command = index === 0 ? 'M' : 'L';
+        return `${command} ${point.x} ${point.y}`;
+      })
+      .join(' ');
+  }
+
+  private scaleValue(
+    value: number,
+    minSource: number,
+    maxSource: number,
+    minTarget: number,
+    maxTarget: number
+  ): number {
+    if (minSource === maxSource) {
+      return (minTarget + maxTarget) / 2;
+    }
+
+    return minTarget + ((value - minSource) * (maxTarget - minTarget)) / (maxSource - minSource);
+  }
+
+  private toIsoDateOrNull(value: string): string | null {
+    if (!value) {
+      return null;
+    }
+
+    return new Date(value).toISOString();
+  }
+
+  getTelemetrySeriesStroke(index: number): string {
+    const colors = [
+      '#38bdf8',
+      '#facc15',
+      '#22c55e',
+      '#f97316',
+      '#a855f7',
+      '#ef4444'
+    ];
+
+    return colors[index % colors.length];
   }
 }

--- a/frontend/src/app/telemetry/models/telemetry-query.model.ts
+++ b/frontend/src/app/telemetry/models/telemetry-query.model.ts
@@ -1,0 +1,12 @@
+export interface TelemetryPoint {
+  timestamp: string;
+  metric: string;
+  value: number;
+}
+
+export interface TelemetryQueryResponse {
+  satelliteId: number;
+  metrics: string[];
+  count: number;
+  points: TelemetryPoint[];
+}

--- a/frontend/src/app/telemetry/services/telemetry.service.ts
+++ b/frontend/src/app/telemetry/services/telemetry.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { TelemetryImportResponse } from '../models/telemetry-import.model';
+import { TelemetryQueryResponse } from '../models/telemetry-query.model';
 
 @Injectable({
   providedIn: 'root'
@@ -23,6 +24,41 @@ export class TelemetryService {
     return this.http.post<TelemetryImportResponse>(
       `${this.apiUrl}/missions/${missionId}/satellites/${satelliteId}/telemetry/import`,
       formData
+    );
+  }
+
+  getAvailableMetrics(satelliteId: number): Observable<string[]> {
+    return this.http.get<string[]>(
+      `${this.apiUrl}/satellites/${satelliteId}/telemetry/metrics`
+    );
+  }
+
+  getTelemetry(
+    satelliteId: number,
+    metrics: string[],
+    from?: string | null,
+    to?: string | null,
+    limit = 5000
+  ): Observable<TelemetryQueryResponse> {
+    let params = new HttpParams();
+
+    metrics.forEach((metric) => {
+      params = params.append('metric', metric);
+    });
+
+    if (from) {
+      params = params.set('from', from);
+    }
+
+    if (to) {
+      params = params.set('to', to);
+    }
+
+    params = params.set('limit', limit);
+
+    return this.http.get<TelemetryQueryResponse>(
+      `${this.apiUrl}/satellites/${satelliteId}/telemetry`,
+      { params }
     );
   }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Résumé</h2><p>Cette PR ajoute l’US16 : visualisation des données de télémétrie sous forme de graphiques.</p><p>Elle permet aux utilisateurs authentifiés de consulter les données de télémétrie importées pour un satellite et d’afficher leur évolution dans le temps sous forme de courbes.</p><p>Les données affichées proviennent de MongoDB, dans la collection <code inline="">telemetry_points</code>, alimentée par l’US15.</p><hr><h2>Changements principaux</h2><ul><li><p>Ajout de l’endpoint de récupération des métriques disponibles :</p><ul><li><p><code inline="">GET /api/satellites/{satelliteId}/telemetry/metrics</code></p></li></ul></li><li><p>Ajout de l’endpoint de lecture des points de télémétrie :</p><ul><li><p><code inline="">GET /api/satellites/{satelliteId}/telemetry</code></p></li></ul></li><li><p>Ajout des DTO de réponse pour la visualisation de télémétrie</p></li><li><p>Ajout d’un service backend de lecture de télémétrie</p></li><li><p>Filtrage par métrique obligatoire</p></li><li><p>Support de plusieurs métriques dans une même requête</p></li><li><p>Filtrage optionnel par période avec <code inline="">from</code> et <code inline="">to</code></p></li><li><p>Limitation du volume de points retournés</p></li><li><p>Tri chronologique des points</p></li><li><p>Lecture autorisée pour ADMIN, OPERATEUR et LECTEUR</p></li><li><p>Ajout de la récupération des métriques côté frontend</p></li><li><p>Ajout de la consultation des points côté frontend</p></li><li><p>Ajout d’une section de visualisation sur la page détail satellite</p></li><li><p>Ajout de graphiques SVG en courbes temporelles</p></li><li><p>Ajout des états loading, vide et erreur</p></li><li><p>Mise à jour du <code inline="">README.md</code></p></li><li><p>Ajout de <code inline="">docs/tests/US16-tests.md</code></p></li></ul><hr><h2>Règles métier</h2><ul><li><p>Seules les données de télémétrie existantes sont affichées</p></li><li><p>Au moins une métrique doit être sélectionnée</p></li><li><p>Les données sont affichées dans l’ordre chronologique</p></li><li><p>Les graphiques sont en lecture seule</p></li><li><p>Les données restent consultables même si la mission est clôturée</p></li><li><p>Les données restent consultables même si le satellite est inactif</p></li><li><p>ADMIN peut consulter</p></li><li><p>OPERATEUR peut consulter</p></li><li><p>LECTEUR peut consulter</p></li><li><p>Un utilisateur non authentifié ne peut pas consulter</p></li></ul><hr><h2>Endpoints ajoutés</h2>
Méthode | Endpoint | Description | Rôles autorisés
-- | -- | -- | --
GET | /api/satellites/{satelliteId}/telemetry/metrics | Récupérer les métriques disponibles | ADMIN, OPERATEUR, LECTEUR
GET | /api/satellites/{satelliteId}/telemetry | Récupérer les points de télémétrie filtrés | ADMIN, OPERATEUR, LECTEUR

<hr><h2>Frontend</h2><p>La page détail satellite contient maintenant une section <code inline="">Visualisation de la télémétrie</code>.</p><p>Cette section permet :</p><ul><li><p>d’afficher les métriques disponibles ;</p></li><li><p>de sélectionner une ou plusieurs métriques ;</p></li><li><p>de filtrer par période ;</p></li><li><p>de rafraîchir les données à la demande ;</p></li><li><p>d’afficher une courbe temporelle par métrique ;</p></li><li><p>d’afficher le nombre de points affichés ;</p></li><li><p>d’afficher le nombre de métriques sélectionnées ;</p></li><li><p>de gérer les états vide, chargement et erreur.</p></li></ul><p>Les graphiques sont générés en SVG côté Angular, sans dépendance graphique externe.</p><hr><h2>Tests backend</h2><p>Les tests backend couvrent :</p><ul><li><p>récupération des métriques disponibles ;</p></li><li><p>lecture d’une métrique ;</p></li><li><p>lecture de plusieurs métriques ;</p></li><li><p>filtre par période ;</p></li><li><p>tri chronologique ;</p></li><li><p>limite de volume ;</p></li><li><p>rejet d’une requête sans métrique ;</p></li><li><p>rejet d’une période invalide ;</p></li><li><p>rejet d’un satellite inexistant ;</p></li><li><p>accès ADMIN ;</p></li><li><p>accès OPERATEUR ;</p></li><li><p>accès LECTEUR ;</p></li><li><p>refus d’un utilisateur non authentifié.</p></li></ul><p>Résultat :</p><p><code inline="">./mvnw test</code></p><p><code inline="">Tests run: 196, Failures: 0, Errors: 0, Skipped: 0</code></p><p><code inline="">BUILD SUCCESS</code></p><hr><h2>Tests frontend</h2><p>Tests réalisés dans le navigateur :</p><ul><li><p>affichage des métriques disponibles ;</p></li><li><p>sélection d’une métrique ;</p></li><li><p>sélection de plusieurs métriques ;</p></li><li><p>affichage d’une courbe par métrique ;</p></li><li><p>rafraîchissement manuel ;</p></li><li><p>filtrage par période ;</p></li><li><p>affichage du nombre de points ;</p></li><li><p>affichage du nombre de métriques sélectionnées ;</p></li><li><p>état vide si aucune donnée ;</p></li><li><p>build Angular.</p></li></ul><p>Résultat :</p><p><code inline="">npm run build</code></p><p><code inline="">Application bundle generation complete</code></p><hr><h2>Validation manuelle</h2><p>Validation réalisée avec un fichier CSV contenant 15 points de télémétrie.</p><p>Métriques testées :</p><ul><li><p><code inline="">battery</code></p></li><li><p><code inline="">speed</code></p></li><li><p><code inline="">temperature</code></p></li></ul><p>Cas validés :</p><ul><li><p>import des données ;</p></li><li><p>détection automatique des métriques disponibles ;</p></li><li><p>affichage des courbes ;</p></li><li><p>affichage multi-métriques ;</p></li><li><p>affichage métrique par métrique ;</p></li><li><p>rafraîchissement ;</p></li><li><p>filtrage par période.</p></li></ul><hr><h2>Notes techniques</h2><p>Les courbes sont affichées avec un SVG généré côté Angular.</p><p>Aucune librairie graphique externe n’a été ajoutée afin de limiter les dépendances et de garder une implémentation simple.</p><p>Le backend utilise <code inline="">MongoTemplate</code> pour construire les requêtes de lecture avec filtres dynamiques.</p><hr><h2>Limites connues</h2><p>Lorsque plusieurs métriques ont des ordres de grandeur très différents, la métrique avec les valeurs les plus élevées peut écraser visuellement les autres.</p><p>Exemple :</p><ul><li><p><code inline="">speed</code> autour de 7600 ;</p></li><li><p><code inline="">battery</code> autour de 70 ;</p></li><li><p><code inline="">temperature</code> autour de 40.</p></li></ul><p>Cette limite est acceptable pour cette US, mais pourra être améliorée avec une normalisation des courbes ou un axe vertical par métrique.</p><hr><h2>Hors périmètre</h2><p>Cette PR ne couvre pas :</p><ul><li><p>la visualisation temps réel ;</p></li><li><p>la détection automatique d’anomalies ;</p></li><li><p>les statistiques avancées ;</p></li><li><p>les seuils graphiques ;</p></li><li><p>le zoom sur une période ;</p></li><li><p>l’export du graphique ;</p></li><li><p>la personnalisation avancée des courbes.</p></li></ul><hr><h2>Documentation</h2><ul><li><p>Mise à jour du <code inline="">README.md</code></p></li><li><p>Ajout de <code inline="">docs/tests/US16-tests.md</code></p></li></ul><hr><h2>Conclusion</h2><p>L’US16 est terminée.</p><p>Les utilisateurs authentifiés peuvent visualiser les données de télémétrie d’un satellite sous forme de graphiques temporels.</p><p>Cette fonctionnalité prépare les prochaines étapes d’analyse et de détection d’anomalies.</p></body></html><!--EndFragment-->
</body>
</html>