### PR TITLE
Feature/us18 anomaly alert generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2044,6 +2044,244 @@ L’US17 ne couvre pas :
 * ajouter des statistiques par métrique ;
 * ajouter des exports CSV/PDF des anomalies.
 
+
+---
+
+## Génération automatique d’alertes à partir des anomalies
+
+L’application génère automatiquement des alertes mission à partir des anomalies de télémétrie détectées.
+
+Cette fonctionnalité permet de transformer une anomalie technique détectée sur les données de télémétrie en alerte opérationnelle visible dans le module Mission Control.
+
+Les anomalies sont stockées dans MongoDB, tandis que les alertes sont stockées en base SQL afin de rester intégrées au module existant de gestion des alertes.
+
+---
+
+### Objectif
+
+Lorsqu’une anomalie est détectée, le système crée automatiquement une alerte associée à la mission et au satellite concernés.
+
+L’alerte permet d’informer les utilisateurs qu’une situation nécessite une attention particulière.
+
+Les alertes générées sont consultables depuis la liste des alertes d’une mission.
+
+---
+
+### Principe de fonctionnement
+
+Flux de traitement :
+
+```text
+Import CSV télémétrie
+        ↓
+Détection d’anomalies
+        ↓
+Persistance des anomalies dans MongoDB
+        ↓
+Génération automatique d’alertes SQL
+        ↓
+Affichage dans les alertes de mission
+```
+
+---
+
+### Données stockées dans une alerte
+
+Une alerte générée depuis une anomalie contient :
+
+- mission associée ;
+- satellite concerné ;
+- métrique impactée ;
+- type d’alerte ;
+- gravité ;
+- statut ;
+- message ;
+- identifiant de l’anomalie d’origine ;
+- valeur de télémétrie détectée ;
+- timestamp de télémétrie ;
+- date de création.
+
+---
+
+### Champs ajoutés à l’entité Alert
+
+Les champs suivants ont été ajoutés à l’entité `Alert` :
+
+| Champ | Description |
+|---|---|
+| `anomalyId` | Identifiant MongoDB de l’anomalie d’origine |
+| `telemetryValue` | Valeur de télémétrie ayant déclenché l’anomalie |
+| `telemetryTimestamp` | Date du point de télémétrie concerné |
+
+Un index unique est appliqué sur `anomaly_id` afin d’éviter la création de doublons.
+
+---
+
+### Types d’alertes générées
+
+Les types d’alertes sont dérivés du type d’anomalie.
+
+| Anomalie | Type d’alerte |
+|---|---|
+| `THRESHOLD` | `ANOMALY_THRESHOLD` |
+| `VARIATION` | `ANOMALY_VARIATION` |
+| `MISSING` | `ANOMALY_MISSING` |
+
+---
+
+### Statut des alertes
+
+Une alerte générée automatiquement est créée avec le statut :
+
+```text
+ACTIVE
+```
+
+Elle peut ensuite être acquittée via le mécanisme existant d’acquittement des alertes.
+
+---
+
+### Règles métier
+
+| Règle | Description |
+|---|---|
+| Création automatique | Une alerte est créée après détection d’une anomalie |
+| Une anomalie, une alerte | Une anomalie génère au maximum une alerte |
+| Statut par défaut | Une alerte générée est créée avec le statut `ACTIVE` |
+| Pas de suppression automatique | Les alertes ne sont pas supprimées automatiquement |
+| Déduplication | Une alerte ne peut pas être créée deux fois pour la même anomalie |
+| Consultation | Les alertes sont visibles depuis la liste des alertes mission |
+| Acquittement | Les alertes peuvent être acquittées via le mécanisme existant |
+
+---
+
+### Endpoint utilisé
+
+Les alertes générées sont consultables via l’endpoint existant :
+
+```http
+GET /api/missions/{missionId}/alerts
+```
+
+Avec filtre optionnel :
+
+```http
+GET /api/missions/{missionId}/alerts?status=ACTIVE
+```
+
+---
+
+### Exemple de réponse
+
+```json
+{
+  "id": 1,
+  "missionId": 4,
+  "missionName": "Mission Luna",
+  "satelliteId": 3,
+  "satelliteName": "LunaSat-03",
+  "metric": "speed",
+  "type": "ANOMALY_THRESHOLD",
+  "severity": "ELEVEE",
+  "status": "ACTIVE",
+  "message": "Anomalie THRESHOLD détectée sur la métrique speed avec la valeur 8050.0.",
+  "anomalyId": "65f...",
+  "telemetryValue": 8050.0,
+  "telemetryTimestamp": "2026-01-01T10:10:00Z",
+  "createdAt": "2026-07-05T22:54:00",
+  "ackAt": null,
+  "ackBy": null
+}
+```
+
+---
+
+### Correction importante
+
+La génération d’alertes ne repose pas uniquement sur les nouvelles anomalies créées.
+
+Le système récupère les anomalies détectées déjà persistées afin de créer les alertes même lorsque les anomalies existaient déjà en MongoDB mais qu’aucune alerte SQL n’avait encore été créée.
+
+Cela corrige le cas suivant :
+
+```text
+Anomalies déjà existantes
+        ↓
+Redétection
+        ↓
+savedCount = 0
+        ↓
+Aucune alerte créée
+```
+
+Après correction :
+
+```text
+Anomalies déjà existantes
+        ↓
+Redétection
+        ↓
+savedCount = 0
+        ↓
+Alertes créées si absentes
+```
+
+---
+
+### Tests réalisés
+
+Les tests backend vérifient :
+
+- la création d’alertes après détection d’anomalies ;
+- la liaison alerte / mission ;
+- la liaison alerte / satellite ;
+- la cohérence des champs `metric`, `type`, `severity`, `value`, `timestamp` ;
+- le statut `ACTIVE` par défaut ;
+- l’absence de doublons lors d’une redétection ;
+- la consultation des alertes via l’endpoint mission.
+
+Résultat :
+
+```text
+200 tests PASS
+BUILD SUCCESS
+```
+
+---
+
+### Validation manuelle
+
+Validation réalisée avec Postman :
+
+```http
+GET /api/missions/4/alerts?status=ACTIVE
+```
+
+Résultat : les alertes générées depuis les anomalies sont bien retournées.
+
+Validation réalisée dans le navigateur :
+
+- page alertes mission accessible ;
+- alertes visibles ;
+- types `ANOMALY_THRESHOLD`, `ANOMALY_VARIATION`, `ANOMALY_MISSING` affichés ;
+- gravités affichées ;
+- statut `ACTIVE` affiché ;
+- bouton d’acquittement disponible.
+
+---
+
+### Hors périmètre
+
+L’US18 ne couvre pas :
+
+- notification email ;
+- notification SMS ;
+- notification push ;
+- escalade automatique ;
+- fusion d’alertes similaires ;
+- corrélation avancée ;
+- création automatique d’incidents.
+
 ---
 
 ## Dashboard mission

--- a/backend/src/main/java/com/finalspace/backend/alert/Alert.java
+++ b/backend/src/main/java/com/finalspace/backend/alert/Alert.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(
@@ -16,7 +17,8 @@ import java.time.LocalDateTime;
         indexes = {
                 @Index(name = "idx_alert_mission", columnList = "mission_id"),
                 @Index(name = "idx_alert_status", columnList = "status"),
-                @Index(name = "idx_alert_created_at", columnList = "created_at")
+                @Index(name = "idx_alert_created_at", columnList = "created_at"),
+                @Index(name = "idx_alert_anomaly_id", columnList = "anomaly_id", unique = true)
         }
 )
 @Getter
@@ -72,4 +74,14 @@ public class Alert {
     @Size(max = 150, message = "L'utilisateur d'acquittement ne doit pas dépasser 150 caractères")
     @Column(length = 150)
     private String ackBy;
+
+    @Size(max = 100, message = "L'identifiant d'anomalie ne doit pas dépasser 100 caractères")
+    @Column(name = "anomaly_id", length = 100, unique = true)
+    private String anomalyId;
+
+    @Column(name = "telemetry_value")
+    private Double telemetryValue;
+
+    @Column(name = "telemetry_timestamp")
+    private Instant telemetryTimestamp;
 }

--- a/backend/src/main/java/com/finalspace/backend/alert/AlertRepository.java
+++ b/backend/src/main/java/com/finalspace/backend/alert/AlertRepository.java
@@ -11,4 +11,6 @@ public interface AlertRepository extends JpaRepository<Alert, Long> {
     List<Alert> findByMissionIdAndStatusOrderByCreatedAtDesc(Long missionId, AlertStatus status);
 
     long countByMissionIdAndStatus(Long missionId, AlertStatus status);
+
+    boolean existsByAnomalyId(String anomalyId);
 }

--- a/backend/src/main/java/com/finalspace/backend/alert/dto/AlertResponse.java
+++ b/backend/src/main/java/com/finalspace/backend/alert/dto/AlertResponse.java
@@ -4,6 +4,7 @@ import com.finalspace.backend.alert.AlertSeverity;
 import com.finalspace.backend.alert.AlertStatus;
 
 import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record AlertResponse(
         Long id,
@@ -16,6 +17,9 @@ public record AlertResponse(
         AlertSeverity severity,
         AlertStatus status,
         String message,
+        String anomalyId,
+        Double telemetryValue,
+        Instant telemetryTimestamp,
         LocalDateTime createdAt,
         LocalDateTime ackAt,
         String ackBy

--- a/backend/src/main/java/com/finalspace/backend/alert/service/AnomalyAlertGenerationService.java
+++ b/backend/src/main/java/com/finalspace/backend/alert/service/AnomalyAlertGenerationService.java
@@ -1,0 +1,10 @@
+package com.finalspace.backend.alert.service;
+
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomaly;
+
+import java.util.List;
+
+public interface AnomalyAlertGenerationService {
+
+    void generateAlertsFromAnomalies(List<TelemetryAnomaly> anomalies);
+}

--- a/backend/src/main/java/com/finalspace/backend/alert/service/impl/AlertServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/alert/service/impl/AlertServiceImpl.java
@@ -59,6 +59,9 @@ public class AlertServiceImpl implements AlertService {
                 alert.getSeverity(),
                 alert.getStatus(),
                 alert.getMessage(),
+                alert.getAnomalyId(),
+                alert.getTelemetryValue(),
+                alert.getTelemetryTimestamp(),
                 alert.getCreatedAt(),
                 alert.getAckAt(),
                 alert.getAckBy()

--- a/backend/src/main/java/com/finalspace/backend/alert/service/impl/AnomalyAlertGenerationServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/alert/service/impl/AnomalyAlertGenerationServiceImpl.java
@@ -1,0 +1,88 @@
+package com.finalspace.backend.alert.service.impl;
+
+import com.finalspace.backend.alert.Alert;
+import com.finalspace.backend.alert.AlertRepository;
+import com.finalspace.backend.alert.AlertSeverity;
+import com.finalspace.backend.alert.AlertStatus;
+import com.finalspace.backend.alert.service.AnomalyAlertGenerationService;
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.mission.MissionRepository;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomaly;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AnomalyAlertGenerationServiceImpl implements AnomalyAlertGenerationService {
+
+    private final AlertRepository alertRepository;
+    private final MissionRepository missionRepository;
+    private final SatelliteRepository satelliteRepository;
+
+    @Override
+    public void generateAlertsFromAnomalies(List<TelemetryAnomaly> anomalies) {
+        if (anomalies == null || anomalies.isEmpty()) {
+            return;
+        }
+
+        for (TelemetryAnomaly anomaly : anomalies) {
+            generateAlertFromAnomaly(anomaly);
+        }
+    }
+
+    private void generateAlertFromAnomaly(TelemetryAnomaly anomaly) {
+        if (anomaly.getId() == null || alertRepository.existsByAnomalyId(anomaly.getId())) {
+            return;
+        }
+
+        Mission mission = missionRepository.findById(anomaly.getMissionId())
+                .orElse(null);
+
+        if (mission == null) {
+            return;
+        }
+
+        Satellite satellite = anomaly.getSatelliteId() == null
+                ? null
+                : satelliteRepository.findById(anomaly.getSatelliteId()).orElse(null);
+
+        Alert alert = Alert.builder()
+                .mission(mission)
+                .satellite(satellite)
+                .metric(anomaly.getMetric())
+                .type("ANOMALY_" + anomaly.getType().name())
+                .severity(AlertSeverity.valueOf(anomaly.getSeverity().name()))
+                .status(AlertStatus.ACTIVE)
+                .message(buildAlertMessage(anomaly))
+                .anomalyId(anomaly.getId())
+                .telemetryValue(anomaly.getValue())
+                .telemetryTimestamp(anomaly.getTimestamp())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        try {
+            alertRepository.save(alert);
+        } catch (DataIntegrityViolationException ignored) {
+            // Protection contre les doublons si deux détections concurrentes créent la même alerte.
+        }
+    }
+
+    private String buildAlertMessage(TelemetryAnomaly anomaly) {
+        return "Anomalie "
+                + anomaly.getType().name()
+                + " détectée sur la métrique "
+                + anomaly.getMetric()
+                + " avec la valeur "
+                + anomaly.getValue()
+                + ". "
+                + anomaly.getMessage();
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/anomaly/TelemetryAnomalyRepository.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/anomaly/TelemetryAnomalyRepository.java
@@ -4,10 +4,19 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 public interface TelemetryAnomalyRepository extends MongoRepository<TelemetryAnomaly, String> {
 
     boolean existsBySatelliteIdAndMetricAndTimestampAndTypeAndRuleName(
+            Long satelliteId,
+            String metric,
+            Instant timestamp,
+            TelemetryAnomalyType type,
+            String ruleName
+    );
+
+    Optional<TelemetryAnomaly> findBySatelliteIdAndMetricAndTimestampAndTypeAndRuleName(
             Long satelliteId,
             String metric,
             Instant timestamp,

--- a/backend/src/main/java/com/finalspace/backend/telemetry/anomaly/service/impl/TelemetryAnomalyDetectionServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/anomaly/service/impl/TelemetryAnomalyDetectionServiceImpl.java
@@ -2,6 +2,7 @@ package com.finalspace.backend.telemetry.anomaly.service.impl;
 
 import com.finalspace.backend.common.exception.BusinessException;
 import com.finalspace.backend.common.exception.ResourceNotFoundException;
+import com.finalspace.backend.alert.service.AnomalyAlertGenerationService;
 import com.finalspace.backend.satellite.SatelliteRepository;
 import com.finalspace.backend.telemetry.TelemetryPoint;
 import com.finalspace.backend.telemetry.anomaly.TelemetryAnomaly;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -49,6 +51,8 @@ public class TelemetryAnomalyDetectionServiceImpl implements TelemetryAnomalyDet
     private final SatelliteRepository satelliteRepository;
     private final MongoTemplate mongoTemplate;
     private final TelemetryAnomalyRepository telemetryAnomalyRepository;
+
+    private final AnomalyAlertGenerationService anomalyAlertGenerationService;
 
     @Override
     public TelemetryAnomalyDetectionResponse detectAnomalies(
@@ -76,6 +80,11 @@ public class TelemetryAnomalyDetectionServiceImpl implements TelemetryAnomalyDet
         }
 
         List<TelemetryAnomaly> savedAnomalies = saveWithoutDuplicates(detectedAnomalies);
+
+        List<TelemetryAnomaly> persistedDetectedAnomalies =
+                findPersistedDetectedAnomalies(detectedAnomalies);
+
+        anomalyAlertGenerationService.generateAlertsFromAnomalies(persistedDetectedAnomalies);
 
         return new TelemetryAnomalyDetectionResponse(
                 satelliteId,
@@ -422,5 +431,21 @@ public class TelemetryAnomalyDetectionServiceImpl implements TelemetryAnomalyDet
             Double criticalMax,
             Double criticalMin
     ) {
+    }
+
+    private List<TelemetryAnomaly> findPersistedDetectedAnomalies(
+            List<TelemetryAnomaly> detectedAnomalies
+    ) {
+        return detectedAnomalies.stream()
+                .map(anomaly -> telemetryAnomalyRepository
+                        .findBySatelliteIdAndMetricAndTimestampAndTypeAndRuleName(
+                                anomaly.getSatelliteId(),
+                                anomaly.getMetric(),
+                                anomaly.getTimestamp(),
+                                anomaly.getType(),
+                                anomaly.getRuleName()
+                        ))
+                .flatMap(Optional::stream)
+                .toList();
     }
 }

--- a/backend/src/test/java/com/finalspace/backend/security/TelemetryImportAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/finalspace/backend/security/TelemetryImportAuthorizationIntegrationTest.java
@@ -1,5 +1,8 @@
 package com.finalspace.backend.security;
 
+import com.finalspace.backend.alert.AlertRepository;
+import com.finalspace.backend.alert.Alert;
+import com.finalspace.backend.alert.AlertStatus;
 import com.finalspace.backend.mission.Mission;
 import com.finalspace.backend.mission.MissionRepository;
 import com.finalspace.backend.mission.MissionStatus;
@@ -21,6 +24,7 @@ import tools.jackson.databind.json.JsonMapper;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.List;
 import tools.jackson.databind.JsonNode;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,10 +52,14 @@ class TelemetryImportAuthorizationIntegrationTest {
     @Autowired
     private TelemetryAnomalyRepository telemetryAnomalyRepository;
 
+    @Autowired
+    private AlertRepository alertRepository;
+
     private final JsonMapper jsonMapper = new JsonMapper();
 
     @BeforeEach
     void cleanDatabase() {
+        alertRepository.deleteAll();
         telemetryAnomalyRepository.deleteAll();
         telemetryPointRepository.deleteAll();
         satelliteRepository.deleteAll();
@@ -360,5 +368,79 @@ class TelemetryImportAuthorizationIntegrationTest {
                 telemetryAnomalyRepository.findBySatelliteIdOrderByTimestampDesc(satellite.getId()).size();
 
         assertThat(anomalyCountAfterSecondDetection).isEqualTo(anomalyCountAfterImport);
+    }
+
+    @Test
+    void shouldAutomaticallyCreateAlertsAfterAnomalyDetectionFromTelemetryImport() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(anomalyCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.importedCount").value(12))
+                .andExpect(jsonPath("$.errorCount").value(0));
+
+        int anomalyCount = telemetryAnomalyRepository
+                .findBySatelliteIdOrderByTimestampDesc(satellite.getId())
+                .size();
+
+        List<Alert> alerts = alertRepository
+                .findByMissionIdOrderByCreatedAtDesc(satellite.getMission().getId());
+
+        assertThat(anomalyCount).isGreaterThan(0);
+        assertThat(alerts).hasSize(anomalyCount);
+
+        assertThat(alerts)
+                .allSatisfy(alert -> {
+                    assertThat(alert.getMission().getId()).isEqualTo(satellite.getMission().getId());
+                    assertThat(alert.getSatellite().getId()).isEqualTo(satellite.getId());
+                    assertThat(alert.getStatus()).isEqualTo(AlertStatus.ACTIVE);
+                    assertThat(alert.getAnomalyId()).isNotBlank();
+                    assertThat(alert.getMetric()).isNotBlank();
+                    assertThat(alert.getType()).startsWith("ANOMALY_");
+                    assertThat(alert.getTelemetryValue()).isNotNull();
+                    assertThat(alert.getTelemetryTimestamp()).isNotNull();
+                    assertThat(alert.getMessage()).contains("Anomalie");
+                });
+    }
+
+    @Test
+    void shouldNotDuplicateAlertsWhenAnomalyDetectionIsRunTwice() throws Exception {
+        String token = loginAndGetToken("admin@finalspace.com", "admin123");
+        Satellite satellite = createActiveSatellite();
+
+        mockMvc.perform(multipart("/api/missions/{missionId}/satellites/{satelliteId}/telemetry/import",
+                        satellite.getMission().getId(),
+                        satellite.getId())
+                        .file(anomalyCsvFile())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.importedCount").value(12))
+                .andExpect(jsonPath("$.errorCount").value(0));
+
+        int alertCountAfterImport = alertRepository
+                .findByMissionIdOrderByCreatedAtDesc(satellite.getMission().getId())
+                .size();
+
+        assertThat(alertCountAfterImport).isGreaterThan(0);
+
+        mockMvc.perform(post("/api/satellites/{satelliteId}/anomalies/detect", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("metric", "battery")
+                        .param("metric", "speed")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.satelliteId").value(satellite.getId()))
+                .andExpect(jsonPath("$.savedCount").value(0));
+
+        int alertCountAfterSecondDetection = alertRepository
+                .findByMissionIdOrderByCreatedAtDesc(satellite.getMission().getId())
+                .size();
+
+        assertThat(alertCountAfterSecondDetection).isEqualTo(alertCountAfterImport);
     }
 }

--- a/backend/src/test/java/com/finalspace/backend/security/TelemetryQueryAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/finalspace/backend/security/TelemetryQueryAuthorizationIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.finalspace.backend.security;
 
+import com.finalspace.backend.alert.AlertRepository;
 import com.finalspace.backend.mission.Mission;
 import com.finalspace.backend.mission.MissionRepository;
 import com.finalspace.backend.mission.MissionStatus;
@@ -45,10 +46,14 @@ class TelemetryQueryAuthorizationIntegrationTest {
     @Autowired
     private TelemetryPointRepository telemetryPointRepository;
 
+    @Autowired
+    private AlertRepository alertRepository;
+
     private final JsonMapper jsonMapper = new JsonMapper();
 
     @BeforeEach
     void cleanDatabase() {
+        alertRepository.deleteAll();
         telemetryPointRepository.deleteAll();
         satelliteRepository.deleteAll();
         missionRepository.deleteAll();

--- a/docs/tests/US18-tests.md
+++ b/docs/tests/US18-tests.md
@@ -1,0 +1,250 @@
+# US18 - Générer automatiquement des alertes à partir des anomalies
+
+## État de validation
+
+**US18 validée côté backend et navigateur.**
+
+L’application génère automatiquement des alertes mission à partir des anomalies de télémétrie détectées.
+
+---
+
+## Objectif de l’US
+
+Permettre au système de créer automatiquement une alerte lorsqu’une anomalie de télémétrie est détectée.
+
+Une alerte représente un signal opérationnel visible dans le module Mission Control.
+
+---
+
+## Dépendances
+
+| User Story | Description | État |
+|---|---|---|
+| US17 | Détection automatique des anomalies | Validée |
+| US08 | Consultation des alertes mission | Validée |
+| US09 | Acquittement des alertes | Validée |
+| US18 | Génération automatique des alertes depuis anomalies | Validée |
+
+---
+
+## Architecture retenue
+
+Les anomalies restent stockées dans MongoDB.
+
+Les alertes sont stockées en SQL, dans la table `alerts`, afin de rester compatibles avec le module Mission Control existant.
+
+Flux :
+
+```text
+TelemetryAnomaly MongoDB
+        ↓
+AnomalyAlertGenerationService
+        ↓
+Alert SQL
+        ↓
+GET /api/missions/{missionId}/alerts
+```
+
+---
+
+## Champs ajoutés à Alert
+
+| Champ | Type | Description |
+|---|---|---|
+| `anomalyId` | String | Identifiant MongoDB de l’anomalie |
+| `telemetryValue` | Double | Valeur de télémétrie liée à l’anomalie |
+| `telemetryTimestamp` | Instant | Timestamp du point de télémétrie concerné |
+
+---
+
+## Règles métier testées
+
+| Règle | Résultat attendu | État |
+|---|---|---|
+| Une anomalie génère une alerte | Une alerte SQL est créée | PASS |
+| Une alerte est liée à une mission | `mission_id` renseigné | PASS |
+| Une alerte est liée à un satellite | `satellite_id` renseigné | PASS |
+| Une alerte est créée ACTIVE | `status = ACTIVE` | PASS |
+| Une anomalie génère au maximum une alerte | Pas de doublon | PASS |
+| Une redétection ne duplique pas les alertes | Nombre d’alertes inchangé | PASS |
+| Les alertes sont consultables par mission | Endpoint mission retourne les alertes | PASS |
+
+---
+
+## Types d’alertes générées
+
+| Type d’anomalie | Type d’alerte attendu | État |
+|---|---|---|
+| `THRESHOLD` | `ANOMALY_THRESHOLD` | PASS |
+| `VARIATION` | `ANOMALY_VARIATION` | PASS |
+| `MISSING` | `ANOMALY_MISSING` | PASS |
+
+---
+
+## Sévérités
+
+Les sévérités des anomalies sont reprises dans les alertes.
+
+| Sévérité anomalie | Sévérité alerte | État |
+|---|---|---|
+| `FAIBLE` | `FAIBLE` | PASS |
+| `MOYENNE` | `MOYENNE` | PASS |
+| `ELEVEE` | `ELEVEE` | PASS |
+
+---
+
+## Tests backend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US18-T01 | Import CSV contenant des anomalies | Import accepté | PASS |
+| US18-T02 | Détection automatique des anomalies | Anomalies créées | PASS |
+| US18-T03 | Génération automatique des alertes | Alertes SQL créées | PASS |
+| US18-T04 | Vérification mission | Les alertes sont liées à la bonne mission | PASS |
+| US18-T05 | Vérification satellite | Les alertes sont liées au bon satellite | PASS |
+| US18-T06 | Vérification statut | Les alertes sont `ACTIVE` | PASS |
+| US18-T07 | Vérification type | Les types commencent par `ANOMALY_` | PASS |
+| US18-T08 | Vérification valeur | `telemetryValue` renseigné | PASS |
+| US18-T09 | Vérification timestamp | `telemetryTimestamp` renseigné | PASS |
+| US18-T10 | Redétection | Pas de doublon d’alertes | PASS |
+| US18-T11 | Consultation mission alerts | Alertes retournées par mission | PASS |
+
+---
+
+## Commande de test backend
+
+Commande exécutée :
+
+```bash
+./mvnw test
+```
+
+Résultat :
+
+```text
+200 tests PASS
+BUILD SUCCESS
+```
+
+---
+
+## Validation Postman
+
+Endpoint testé :
+
+```http
+GET /api/missions/4/alerts?status=ACTIVE
+```
+
+Résultat attendu :
+
+- liste non vide ;
+- alertes avec statut `ACTIVE` ;
+- types `ANOMALY_THRESHOLD`, `ANOMALY_VARIATION`, `ANOMALY_MISSING` ;
+- mission correcte ;
+- satellite correct ;
+- métrique correcte ;
+- valeur de télémétrie renseignée.
+
+Résultat obtenu :
+
+```text
+PASS
+```
+
+---
+
+## Validation navigateur
+
+La page des alertes mission affiche correctement les alertes générées depuis les anomalies.
+
+Cas validés :
+
+- affichage de la liste des alertes ;
+- affichage du type ;
+- affichage de la gravité ;
+- affichage du statut ;
+- affichage du satellite ;
+- affichage de la métrique ;
+- affichage du message ;
+- affichage de la date de création ;
+- bouton d’acquittement disponible.
+
+Résultat :
+
+```text
+PASS
+```
+
+---
+
+## Correction réalisée pendant l’US
+
+Un cas spécifique a été corrigé.
+
+Situation initiale :
+
+```text
+Anomalies déjà existantes en MongoDB
+        ↓
+Redétection
+        ↓
+savedCount = 0
+        ↓
+Aucune alerte créée
+```
+
+Correction :
+
+Le service récupère maintenant les anomalies détectées déjà persistées afin de générer les alertes manquantes même si les anomalies ne sont pas nouvellement sauvegardées.
+
+Situation corrigée :
+
+```text
+Anomalies déjà existantes
+        ↓
+Redétection
+        ↓
+savedCount = 0
+        ↓
+Alertes créées si absentes
+```
+
+---
+
+## Fichiers principaux modifiés
+
+| Fichier | Rôle |
+|---|---|
+| `Alert.java` | Ajout des champs liés à l’anomalie |
+| `AlertRepository.java` | Ajout de la recherche par `anomalyId` |
+| `AlertResponse.java` | Exposition des nouveaux champs |
+| `AlertServiceImpl.java` | Mapping des nouveaux champs |
+| `AnomalyAlertGenerationService.java` | Interface de génération |
+| `AnomalyAlertGenerationServiceImpl.java` | Génération des alertes |
+| `TelemetryAnomalyRepository.java` | Recherche des anomalies déjà persistées |
+| `TelemetryAnomalyDetectionServiceImpl.java` | Déclenchement de génération d’alertes |
+| `TelemetryImportAuthorizationIntegrationTest.java` | Tests US18 |
+| `TelemetryQueryAuthorizationIntegrationTest.java` | Nettoyage des alertes dans les tests |
+
+---
+
+## Hors périmètre
+
+L’US18 ne couvre pas :
+
+- notification email ;
+- notification SMS ;
+- notification push ;
+- escalade automatique ;
+- fusion d’alertes similaires ;
+- corrélation avancée d’alertes ;
+- création automatique d’incidents.
+
+---
+
+## Conclusion
+
+L’US18 est validée.
+
+Les anomalies de télémétrie génèrent automatiquement des alertes mission persistées en SQL, consultables depuis le module Mission Control et non dupliquées en cas de redétection.


### PR DESCRIPTION
## Résumé

Cette PR ajoute l’US18 : génération automatique d’alertes mission à partir des anomalies de télémétrie détectées.

Lorsqu’une anomalie est détectée, le système crée automatiquement une alerte SQL associée à la mission et au satellite concernés.

Les alertes sont visibles dans la liste des alertes de la mission et peuvent être acquittées via le mécanisme existant.

---

## Changements principaux

- Ajout d’un lien entre `TelemetryAnomaly` et `Alert`
- Ajout du champ `anomalyId` dans `Alert`
- Ajout des champs `telemetryValue` et `telemetryTimestamp`
- Ajout d’un index unique sur `anomaly_id`
- Création du service `AnomalyAlertGenerationService`
- Génération automatique des alertes après détection d’anomalies
- Déduplication des alertes : une anomalie génère au maximum une alerte
- Mise à jour de `AlertResponse`
- Intégration avec `GET /api/missions/{missionId}/alerts`
- Tests backend ajoutés pour vérifier la génération et l’absence de doublons

---

## Règles métier

- Une anomalie génère au maximum une alerte
- Une alerte générée est créée avec le statut `ACTIVE`
- Les alertes ne sont pas supprimées automatiquement
- Les alertes sont associées à une mission
- Les alertes sont associées au satellite concerné si disponible
- Les alertes conservent la métrique, la valeur et le timestamp de télémétrie
- Les alertes restent consultables depuis le module Mission Control
- Les alertes peuvent être acquittées par le mécanisme existant

---

## Correction importante

La génération d’alertes ne repose pas uniquement sur les nouvelles anomalies sauvegardées.

Le service récupère maintenant les anomalies détectées déjà persistées afin de permettre la création d’alertes même lorsque les anomalies existaient déjà en MongoDB mais qu’aucune alerte SQL n’avait encore été créée.

Cela évite le cas suivant :

- anomalies présentes ;
- redétection avec `savedCount = 0` ;
- aucune alerte créée.

---

## Tests

Résultat backend :

`./mvnw test`

`200 tests PASS`

Tests validés :

- anomalies détectées vers alertes créées ;
- alertes liées à la bonne mission ;
- alertes liées au bon satellite ;
- statut `ACTIVE` par défaut ;
- pas de doublons si la détection est relancée ;
- consultation via `/api/missions/{missionId}/alerts`;
- consultation avec filtre `status=ACTIVE`.

---

## Validation manuelle

Validation réalisée avec Postman :

`GET /api/missions/4/alerts?status=ACTIVE`

Résultat : les alertes générées depuis les anomalies sont bien retournées.

Validation réalisée dans le navigateur :

- page alertes mission accessible ;
- alertes visibles ;
- types `ANOMALY_THRESHOLD`, `ANOMALY_VARIATION`, `ANOMALY_MISSING` affichés ;
- gravités affichées ;
- statut `ACTIVE` affiché ;
- bouton d’acquittement disponible.

---

## Hors périmètre

Cette PR ne couvre pas :

- notifications email/SMS/push ;
- escalade automatique ;
- corrélation avancée d’alertes ;
- fusion d’alertes similaires ;
- création automatique d’incidents.