### PR TITLE
feat(simulations): export results as csv and pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -2282,6 +2282,196 @@ L’US18 ne couvre pas :
 - corrélation avancée ;
 - création automatique d’incidents.
 
+
+---
+
+## Exporter les résultats de simulation CSV / PDF
+
+L’application permet d’exporter les résultats d’une simulation orbitale ou d’un transfert de Hohmann.
+
+Les exports sont générés à la demande depuis le détail d’une simulation et ne modifient pas les données en base.
+
+Deux formats sont disponibles :
+
+- `CSV` : destiné à l’analyse de données ou à l’exploitation externe ;
+- `PDF` : destiné au partage ou à l’archivage sous forme de rapport lisible.
+
+---
+
+### Objectif
+
+Permettre à un utilisateur autorisé d’exporter les paramètres et résultats d’une simulation enregistrée.
+
+L’export reflète les données persistées de la simulation sélectionnée.
+
+---
+
+### Types de simulations supportés
+
+| Type | Description |
+|---|---|
+| `ORBIT` | Simulation orbitale |
+| `HOHMANN` | Manœuvre de transfert de Hohmann |
+
+---
+
+### Endpoints API
+
+| Méthode | Endpoint | Format | Rôles autorisés |
+|---|---|---|---|
+| `GET` | `/api/simulations/{id}/export/csv` | CSV | ADMIN, OPERATEUR, LECTEUR |
+| `GET` | `/api/simulations/{id}/export/pdf` | PDF | ADMIN, OPERATEUR, LECTEUR |
+
+---
+
+### Export CSV
+
+Le fichier CSV utilise un format à colonnes fixes.
+
+Colonnes exportées :
+
+```text
+simulationId;missionId;missionName;satelliteId;satelliteName;type;status;createdAt;createdBy;inputMassKg;inputAltitudeKm;inputInclinationDeg;inputEccentricity;targetAltitudeKm;orbitalPeriodMinutes;averageVelocityKmS;orbitShape;deltaV1MS;deltaV2MS;deltaVTotalMS;transferTimeMinutes
+```
+
+Le séparateur utilisé est `;` afin d’assurer une ouverture correcte dans Excel en environnement français.
+
+Le fichier est encodé en UTF-8 avec BOM pour préserver les caractères accentués.
+
+---
+
+### Exemple CSV ORBIT
+
+```csv
+simulationId;missionId;missionName;satelliteId;satelliteName;type;status;createdAt;createdBy;inputMassKg;inputAltitudeKm;inputInclinationDeg;inputEccentricity;targetAltitudeKm;orbitalPeriodMinutes;averageVelocityKmS;orbitShape;deltaV1MS;deltaV2MS;deltaVTotalMS;transferTimeMinutes
+24;4;Mission to the MOOOOON;3;LunaSat-03;ORBIT;SUCCESS;2026-07-06T00:56:57.705593;admin@finalspace.com;850.0;500.0;95.0;0.4;;94.47;7.62;ELLIPTIQUE;;;;
+```
+
+---
+
+### Exemple CSV HOHMANN
+
+```csv
+simulationId;missionId;missionName;satelliteId;satelliteName;type;status;createdAt;createdBy;inputMassKg;inputAltitudeKm;inputInclinationDeg;inputEccentricity;targetAltitudeKm;orbitalPeriodMinutes;averageVelocityKmS;orbitShape;deltaV1MS;deltaV2MS;deltaVTotalMS;transferTimeMinutes
+25;4;Mission to the MOOOOON;3;LunaSat-03;HOHMANN;SUCCESS;2026-07-06T01:05:00;admin@finalspace.com;850.0;500.0;95.0;0.4;1200.0;;;;123.4;121.8;245.2;52.7
+```
+
+---
+
+### Export PDF
+
+Le PDF est généré avec OpenPDF `3.0.5`.
+
+Le rapport contient :
+
+- un titre ;
+- la date de génération ;
+- les métadonnées de la simulation ;
+- un tableau des paramètres d’entrée ;
+- un tableau des résultats calculés ;
+- un pied de page indiquant que le rapport est généré automatiquement.
+
+---
+
+### Contenu du PDF
+
+#### Métadonnées
+
+- identifiant de simulation ;
+- mission ;
+- satellite ;
+- type ;
+- statut ;
+- date de création ;
+- auteur.
+
+#### Paramètres
+
+- masse ;
+- altitude initiale ;
+- inclinaison ;
+- excentricité ;
+- altitude cible pour les simulations `HOHMANN`.
+
+#### Résultats ORBIT
+
+- période orbitale ;
+- vitesse moyenne ;
+- forme de l’orbite.
+
+#### Résultats HOHMANN
+
+- delta V1 ;
+- delta V2 ;
+- delta V total ;
+- durée du transfert.
+
+---
+
+### Frontend
+
+La page détail simulation affiche une section `Exports`.
+
+Elle propose deux boutons :
+
+- `Exporter CSV`
+- `Exporter PDF`
+
+Le téléchargement est déclenché directement depuis le navigateur.
+
+Les erreurs `403` et `404` sont gérées côté interface.
+
+---
+
+### Règles métier
+
+| Règle | Description |
+|---|---|
+| Export à la demande | L’export est lancé uniquement par action utilisateur |
+| Simulation ciblée | Chaque export correspond à une simulation précise |
+| Données persistées | L’export utilise les données enregistrées en base |
+| Aucune modification | L’export ne modifie pas la base de données |
+| Format CSV unique | Les simulations ORBIT et HOHMANN partagent les mêmes colonnes |
+| Format PDF standardisé | Un modèle PDF unique est utilisé |
+| Accès lecteur | Le rôle LECTEUR peut exporter une simulation |
+
+---
+
+### Tests réalisés
+
+Les tests backend vérifient :
+
+- export CSV non vide ;
+- export PDF non vide ;
+- fichier PDF valide ;
+- headers `Content-Type` ;
+- headers `Content-Disposition` ;
+- export CSV pour simulation `ORBIT` ;
+- export CSV pour simulation `HOHMANN` ;
+- export PDF pour simulation `ORBIT` ;
+- export PDF pour simulation `HOHMANN` ;
+- accès autorisé pour `LECTEUR`.
+
+Validation manuelle :
+
+- téléchargement CSV depuis le navigateur ;
+- téléchargement PDF depuis le navigateur ;
+- ouverture correcte du CSV dans Excel ;
+- ouverture correcte du PDF ;
+- test avec un compte LECTEUR.
+
+---
+
+### Hors périmètre
+
+L’US19 ne couvre pas :
+
+- personnalisation du modèle PDF ;
+- export multi-simulations ;
+- envoi automatique par email ;
+- archivage automatique des exports ;
+- génération planifiée des rapports.
+
 ---
 
 ## Dashboard mission

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -166,6 +166,13 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<!-- PDF export -->
+		<dependency>
+			<groupId>com.github.librepdf</groupId>
+			<artifactId>openpdf</artifactId>
+			<version>3.0.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/finalspace/backend/simulation/controller/SimulationExportController.java
+++ b/backend/src/main/java/com/finalspace/backend/simulation/controller/SimulationExportController.java
@@ -1,0 +1,51 @@
+package com.finalspace.backend.simulation.controller;
+
+import com.finalspace.backend.simulation.export.SimulationExportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/simulations/{id}/export")
+public class SimulationExportController {
+
+    private final SimulationExportService simulationExportService;
+
+    @GetMapping("/csv")
+    public ResponseEntity<byte[]> exportCsv(@PathVariable Long id) {
+        byte[] csv = simulationExportService.generateSimulationCsv(id);
+
+        return ResponseEntity.ok()
+                .contentType(new MediaType("text", "csv", StandardCharsets.UTF_8))
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment()
+                                .filename(simulationExportService.buildCsvFilename(id), StandardCharsets.UTF_8)
+                                .build()
+                                .toString()
+                )
+                .body(csv);
+    }
+
+    @GetMapping("/pdf")
+    public ResponseEntity<byte[]> exportPdf(@PathVariable Long id) {
+        byte[] pdf = simulationExportService.generateSimulationPdf(id);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment()
+                                .filename(simulationExportService.buildPdfFilename(id), StandardCharsets.UTF_8)
+                                .build()
+                                .toString()
+                )
+                .body(pdf);
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/simulation/export/SimulationExportService.java
+++ b/backend/src/main/java/com/finalspace/backend/simulation/export/SimulationExportService.java
@@ -1,0 +1,12 @@
+package com.finalspace.backend.simulation.export;
+
+public interface SimulationExportService {
+
+    byte[] generateSimulationCsv(Long simulationId);
+
+    byte[] generateSimulationPdf(Long simulationId);
+
+    String buildCsvFilename(Long simulationId);
+
+    String buildPdfFilename(Long simulationId);
+}

--- a/backend/src/main/java/com/finalspace/backend/simulation/export/SimulationExportServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/simulation/export/SimulationExportServiceImpl.java
@@ -1,0 +1,268 @@
+package com.finalspace.backend.simulation.export;
+
+import com.finalspace.backend.common.exception.ResourceNotFoundException;
+import com.finalspace.backend.simulation.SimulationRun;
+import com.finalspace.backend.simulation.SimulationRunRepository;
+import com.finalspace.backend.simulation.SimulationType;
+import org.openpdf.text.Document;
+import org.openpdf.text.DocumentException;
+import org.openpdf.text.Element;
+import org.openpdf.text.FontFactory;
+import org.openpdf.text.PageSize;
+import org.openpdf.text.Paragraph;
+import org.openpdf.text.Phrase;
+import org.openpdf.text.pdf.PdfPCell;
+import org.openpdf.text.pdf.PdfPTable;
+import org.openpdf.text.pdf.PdfWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SimulationExportServiceImpl implements SimulationExportService {
+
+    private final SimulationRunRepository simulationRunRepository;
+
+    @Override
+    public byte[] generateSimulationCsv(Long simulationId) {
+        SimulationRun run = getSimulationRun(simulationId);
+
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("simulationId;")
+                .append("missionId;")
+                .append("missionName;")
+                .append("satelliteId;")
+                .append("satelliteName;")
+                .append("type;")
+                .append("status;")
+                .append("createdAt;")
+                .append("createdBy;")
+                .append("inputMassKg;")
+                .append("inputAltitudeKm;")
+                .append("inputInclinationDeg;")
+                .append("inputEccentricity;")
+                .append("targetAltitudeKm;")
+                .append("orbitalPeriodMinutes;")
+                .append("averageVelocityKmS;")
+                .append("orbitShape;")
+                .append("deltaV1MS;")
+                .append("deltaV2MS;")
+                .append("deltaVTotalMS;")
+                .append("transferTimeMinutes")
+                .append("\r\n");
+
+        csv.append(csvValue(run.getId())).append(';')
+                .append(csvValue(run.getMission().getId())).append(';')
+                .append(csvValue(run.getMission().getName())).append(';')
+                .append(csvValue(run.getSatellite().getId())).append(';')
+                .append(csvValue(run.getSatellite().getName())).append(';')
+                .append(csvValue(run.getType())).append(';')
+                .append(csvValue(run.getStatus())).append(';')
+                .append(csvValue(run.getCreatedAt())).append(';')
+                .append(csvValue(run.getCreatedBy())).append(';')
+                .append(csvValue(run.getInputMassKg())).append(';')
+                .append(csvValue(run.getInputAltitudeKm())).append(';')
+                .append(csvValue(run.getInputInclinationDeg())).append(';')
+                .append(csvValue(run.getInputEccentricity())).append(';')
+                .append(csvValue(run.getTargetAltitudeKm())).append(';')
+                .append(csvValue(run.getOrbitalPeriodMinutes())).append(';')
+                .append(csvValue(run.getAverageVelocityKmS())).append(';')
+                .append(csvValue(run.getOrbitShape())).append(';')
+                .append(csvValue(run.getDeltaV1MS())).append(';')
+                .append(csvValue(run.getDeltaV2MS())).append(';')
+                .append(csvValue(run.getDeltaVTotalMS())).append(';')
+                .append(csvValue(run.getTransferTimeMinutes()))
+                .append("\r\n");
+
+        return ("\uFEFF" + csv).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public byte[] generateSimulationPdf(Long simulationId) {
+        SimulationRun run = getSimulationRun(simulationId);
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4, 40, 40, 40, 40);
+            PdfWriter.getInstance(document, outputStream);
+
+            document.open();
+
+            Paragraph title = new Paragraph(
+                    "Final Space - Rapport de simulation",
+                    FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18)
+            );
+            title.setAlignment(Element.ALIGN_CENTER);
+            title.setSpacingAfter(20);
+            document.add(title);
+
+            Paragraph generationDate = new Paragraph(
+                    "Date de génération : " + LocalDateTime.now(),
+                    FontFactory.getFont(FontFactory.HELVETICA, 10)
+            );
+            generationDate.setSpacingAfter(20);
+            document.add(generationDate);
+
+            addSectionTitle(document, "Métadonnées");
+            PdfPTable metadataTable = createTable();
+            addTableHeader(metadataTable, "Champ", "Valeur", "Unité");
+            addTableRow(metadataTable, "Simulation ID", run.getId(), "");
+            addTableRow(metadataTable, "Mission", run.getMission().getName() + " (#" + run.getMission().getId() + ")", "");
+            addTableRow(metadataTable, "Satellite", run.getSatellite().getName() + " (#" + run.getSatellite().getId() + ")", "");
+            addTableRow(metadataTable, "Type", run.getType(), "");
+            addTableRow(metadataTable, "Statut", run.getStatus(), "");
+            addTableRow(metadataTable, "Créée le", run.getCreatedAt(), "");
+            addTableRow(metadataTable, "Créée par", run.getCreatedBy(), "");
+            document.add(metadataTable);
+
+            addSectionTitle(document, "Paramètres d'entrée");
+            PdfPTable inputsTable = createTable();
+            addTableHeader(inputsTable, "Paramètre", "Valeur", "Unité");
+            addTableRow(inputsTable, "Masse", run.getInputMassKg(), "kg");
+            addTableRow(inputsTable, "Altitude initiale", run.getInputAltitudeKm(), "km");
+            addTableRow(inputsTable, "Inclinaison", run.getInputInclinationDeg(), "deg");
+            addTableRow(inputsTable, "Excentricité", run.getInputEccentricity(), "");
+
+            if (run.getType() == SimulationType.HOHMANN) {
+                addTableRow(inputsTable, "Altitude cible", run.getTargetAltitudeKm(), "km");
+            }
+
+            document.add(inputsTable);
+
+            addSectionTitle(document, "Résultats");
+            PdfPTable resultsTable = createTable();
+            addTableHeader(resultsTable, "Résultat", "Valeur", "Unité");
+
+            if (run.getType() == SimulationType.ORBIT) {
+                addTableRow(resultsTable, "Période orbitale", run.getOrbitalPeriodMinutes(), "min");
+                addTableRow(resultsTable, "Vitesse moyenne", run.getAverageVelocityKmS(), "km/s");
+                addTableRow(resultsTable, "Forme de l'orbite", run.getOrbitShape(), "");
+            }
+
+            if (run.getType() == SimulationType.HOHMANN) {
+                addTableRow(resultsTable, "Delta V1", run.getDeltaV1MS(), "m/s");
+                addTableRow(resultsTable, "Delta V2", run.getDeltaV2MS(), "m/s");
+                addTableRow(resultsTable, "Delta V total", run.getDeltaVTotalMS(), "m/s");
+                addTableRow(resultsTable, "Durée du transfert", run.getTransferTimeMinutes(), "min");
+            }
+
+            document.add(resultsTable);
+
+            Paragraph footer = new Paragraph(
+                    "Rapport généré automatiquement par Final Space. Les données exportées correspondent à la simulation sélectionnée et ne modifient pas les données en base.",
+                    FontFactory.getFont(FontFactory.HELVETICA_OBLIQUE, 9)
+            );
+            footer.setSpacingBefore(24);
+            document.add(footer);
+
+            document.close();
+
+            return outputStream.toByteArray();
+        } catch (DocumentException exception) {
+            throw new IllegalStateException("Impossible de générer le rapport PDF de simulation", exception);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Erreur inattendue pendant la génération du rapport PDF", exception);
+        }
+    }
+
+    @Override
+    public String buildCsvFilename(Long simulationId) {
+        return "simulation-" + simulationId + ".csv";
+    }
+
+    @Override
+    public String buildPdfFilename(Long simulationId) {
+        return "simulation-" + simulationId + ".pdf";
+    }
+
+    private SimulationRun getSimulationRun(Long simulationId) {
+        return simulationRunRepository.findById(simulationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Simulation introuvable"));
+    }
+
+    private String csvValue(Object value) {
+        if (value == null) {
+            return "";
+        }
+
+        String text = value.toString();
+
+        if (
+                text.contains(";")
+                        || text.contains("\"")
+                        || text.contains("\n")
+                        || text.contains("\r")
+        ) {
+            return "\"" + text.replace("\"", "\"\"") + "\"";
+        }
+
+        return text;
+    }
+
+    private void addSectionTitle(Document document, String title) throws DocumentException {
+        Paragraph paragraph = new Paragraph(
+                title,
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14)
+        );
+        paragraph.setSpacingBefore(12);
+        paragraph.setSpacingAfter(8);
+        document.add(paragraph);
+    }
+
+    private PdfPTable createTable() throws DocumentException {
+        PdfPTable table = new PdfPTable(3);
+        table.setWidthPercentage(100);
+        table.setWidths(new float[]{35, 45, 20});
+        table.setSpacingAfter(12);
+        return table;
+    }
+
+    private void addTableHeader(
+            PdfPTable table,
+            String firstColumn,
+            String secondColumn,
+            String thirdColumn
+    ) {
+        table.addCell(createHeaderCell(firstColumn));
+        table.addCell(createHeaderCell(secondColumn));
+        table.addCell(createHeaderCell(thirdColumn));
+    }
+
+    private void addTableRow(
+            PdfPTable table,
+            String name,
+            Object value,
+            String unit
+    ) {
+        table.addCell(createBodyCell(name));
+        table.addCell(createBodyCell(value == null ? "-" : value.toString()));
+        table.addCell(createBodyCell(unit == null ? "" : unit));
+    }
+
+    private PdfPCell createHeaderCell(String value) {
+        PdfPCell cell = new PdfPCell(new Phrase(
+                value,
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 10)
+        ));
+        cell.setBackgroundColor(new Color(230, 230, 230));
+        cell.setHorizontalAlignment(Element.ALIGN_LEFT);
+        cell.setPadding(6);
+        return cell;
+    }
+
+    private PdfPCell createBodyCell(String value) {
+        PdfPCell cell = new PdfPCell(new Phrase(
+                value,
+                FontFactory.getFont(FontFactory.HELVETICA, 10)
+        ));
+        cell.setPadding(6);
+        return cell;
+    }
+}

--- a/docs/tests/US19-tests.md
+++ b/docs/tests/US19-tests.md
@@ -1,0 +1,240 @@
+# US19 - Exporter les résultats de simulation CSV / PDF
+
+## État de validation
+
+**US19 validée côté backend et frontend.**
+
+L’application permet d’exporter les résultats d’une simulation orbitale ou d’un transfert de Hohmann aux formats CSV et PDF.
+
+---
+
+## Objectif de l’US
+
+Permettre à un utilisateur autorisé d’exporter les résultats d’une simulation afin de les analyser, les archiver ou les partager.
+
+---
+
+## Dépendances
+
+| User Story | Description | État |
+|---|---|---|
+| US12 | Lancer une simulation orbitale | Validée |
+| US13 | Lancer une manœuvre de transfert de Hohmann | Validée |
+| US14 | Historique des simulations | Validée |
+| US19 | Export simulation CSV / PDF | Validée |
+
+---
+
+## Endpoints testés
+
+| Méthode | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/simulations/{id}/export/csv` | Export CSV |
+| `GET` | `/api/simulations/{id}/export/pdf` | Export PDF |
+
+---
+
+## Rôles testés
+
+| Rôle | Résultat attendu | État |
+|---|---|---|
+| ADMIN | Export autorisé | PASS |
+| OPERATEUR | Export autorisé | PASS |
+| LECTEUR | Export autorisé | PASS |
+| Non connecté | Accès refusé | PASS |
+
+---
+
+## Export CSV
+
+Le CSV est généré en mémoire depuis les données persistées de la simulation.
+
+Format :
+
+```text
+simulationId;missionId;missionName;satelliteId;satelliteName;type;status;createdAt;createdBy;inputMassKg;inputAltitudeKm;inputInclinationDeg;inputEccentricity;targetAltitudeKm;orbitalPeriodMinutes;averageVelocityKmS;orbitShape;deltaV1MS;deltaV2MS;deltaVTotalMS;transferTimeMinutes
+```
+
+Le séparateur utilisé est `;`.
+
+L’encodage est UTF-8 avec BOM afin de garantir une ouverture correcte dans Excel FR.
+
+---
+
+## Export PDF
+
+Le PDF est généré avec OpenPDF `3.0.5`.
+
+Le rapport contient :
+
+- titre du rapport ;
+- date de génération ;
+- métadonnées ;
+- tableau des paramètres ;
+- tableau des résultats ;
+- mention de génération automatique.
+
+---
+
+## Tests backend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US19-T01 | Export CSV simulation ORBIT | Fichier CSV retourné | PASS |
+| US19-T02 | Export CSV simulation HOHMANN | Fichier CSV retourné | PASS |
+| US19-T03 | Export PDF simulation ORBIT | Fichier PDF retourné | PASS |
+| US19-T04 | Export PDF simulation HOHMANN | Fichier PDF retourné | PASS |
+| US19-T05 | CSV contient les colonnes fixes | Header correct | PASS |
+| US19-T06 | CSV contient les métadonnées | Simulation, mission, satellite présents | PASS |
+| US19-T07 | CSV contient les inputs | Masse, altitude, inclinaison, excentricité présents | PASS |
+| US19-T08 | CSV ORBIT contient les résultats orbitaux | Période, vitesse, forme présents | PASS |
+| US19-T09 | CSV HOHMANN contient les résultats Hohmann | Delta V et durée présents | PASS |
+| US19-T10 | PDF commence par `%PDF` | PDF valide | PASS |
+| US19-T11 | PDF non vide | Taille supérieure à 0 | PASS |
+| US19-T12 | Content-Type CSV | `text/csv` | PASS |
+| US19-T13 | Content-Type PDF | `application/pdf` | PASS |
+| US19-T14 | Content-Disposition CSV | Téléchargement fichier `.csv` | PASS |
+| US19-T15 | Content-Disposition PDF | Téléchargement fichier `.pdf` | PASS |
+| US19-T16 | Simulation introuvable | Erreur 404 | PASS |
+| US19-T17 | Utilisateur LECTEUR | Export autorisé | PASS |
+| US19-T18 | Utilisateur non connecté | Accès refusé | PASS |
+
+---
+
+## Tests frontend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US19-T19 | Affichage section exports | Boutons visibles sur détail simulation | PASS |
+| US19-T20 | Clic Exporter CSV | Fichier CSV téléchargé | PASS |
+| US19-T21 | Clic Exporter PDF | Fichier PDF téléchargé | PASS |
+| US19-T22 | Export simulation ORBIT | Téléchargement OK | PASS |
+| US19-T23 | Export simulation HOHMANN | Téléchargement OK | PASS |
+| US19-T24 | Compte LECTEUR | Boutons fonctionnels | PASS |
+| US19-T25 | Erreur 403 | Redirection forbidden | PASS |
+| US19-T26 | Erreur 404 | Message simulation introuvable | PASS |
+| US19-T27 | Build frontend | Build OK | PASS |
+
+---
+
+## Commandes de validation
+
+Backend :
+
+```bash
+./mvnw test
+```
+
+Résultat attendu :
+
+```text
+BUILD SUCCESS
+```
+
+Frontend :
+
+```bash
+npm run build
+```
+
+Résultat attendu :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+## Validation Postman
+
+Endpoints validés :
+
+```http
+GET /api/simulations/{id}/export/csv
+GET /api/simulations/{id}/export/pdf
+```
+
+Cas validés :
+
+- export CSV avec token ADMIN ;
+- export PDF avec token ADMIN ;
+- export CSV avec token LECTEUR ;
+- export PDF avec token LECTEUR ;
+- simulation inexistante ;
+- utilisateur non authentifié.
+
+Résultat :
+
+```text
+PASS
+```
+
+---
+
+## Validation navigateur
+
+La page détail simulation permet de télécharger les exports.
+
+Cas validés :
+
+- ouverture détail simulation ;
+- bouton `Exporter CSV` visible ;
+- bouton `Exporter PDF` visible ;
+- téléchargement CSV fonctionnel ;
+- téléchargement PDF fonctionnel ;
+- CSV correctement séparé en colonnes dans Excel ;
+- PDF ouvrable et lisible ;
+- test réalisé avec un utilisateur LECTEUR.
+
+Résultat :
+
+```text
+PASS
+```
+
+---
+
+## Format CSV final
+
+Exemple pour une simulation ORBIT :
+
+```csv
+simulationId;missionId;missionName;satelliteId;satelliteName;type;status;createdAt;createdBy;inputMassKg;inputAltitudeKm;inputInclinationDeg;inputEccentricity;targetAltitudeKm;orbitalPeriodMinutes;averageVelocityKmS;orbitShape;deltaV1MS;deltaV2MS;deltaVTotalMS;transferTimeMinutes
+24;4;Mission to the MOOOOON;3;LunaSat-03;ORBIT;SUCCESS;2026-07-06T00:56:57.705593;admin@finalspace.com;850.0;500.0;95.0;0.4;;94.47;7.62;ELLIPTIQUE;;;;
+```
+
+---
+
+## Fichiers principaux modifiés
+
+| Fichier | Rôle |
+|---|---|
+| `pom.xml` | Ajout OpenPDF 3.0.5 |
+| `SimulationExportService.java` | Interface du service d’export |
+| `SimulationExportServiceImpl.java` | Génération CSV et PDF |
+| `SimulationExportController.java` | Endpoints de téléchargement |
+| `simulation.service.ts` | Appels HTTP export CSV/PDF |
+| `simulation-detail.component.ts` | Logique de téléchargement |
+| `simulation-detail.component.html` | Boutons d’export |
+| `simulation-detail.component.css` | Styles de la section export |
+
+---
+
+## Hors périmètre
+
+L’US19 ne couvre pas :
+
+- personnalisation du modèle PDF ;
+- export de plusieurs simulations en une seule opération ;
+- envoi automatique par email ;
+- archivage automatique ;
+- export planifié ;
+- signature numérique des PDF.
+
+---
+
+## Conclusion
+
+L’US19 est validée.
+
+Les utilisateurs autorisés peuvent exporter une simulation précise en CSV ou PDF depuis le détail de simulation. Les fichiers générés reflètent les données enregistrées, sans modifier la base.

--- a/frontend/src/app/simulations/services/simulation.service.ts
+++ b/frontend/src/app/simulations/services/simulation.service.ts
@@ -40,4 +40,22 @@ export class SimulationService {
       `${this.apiUrl}/simulations/${simulationId}`
     );
   }
+
+  exportCsv(simulationId: number): Observable<Blob> {
+    return this.http.get(
+      `${this.apiUrl}/simulations/${simulationId}/export/csv`,
+      {
+        responseType: 'blob'
+      }
+    );
+  }
+
+  exportPdf(simulationId: number): Observable<Blob> {
+    return this.http.get(
+      `${this.apiUrl}/simulations/${simulationId}/export/pdf`,
+      {
+        responseType: 'blob'
+      }
+    );
+  }
 }

--- a/frontend/src/app/simulations/simulation-detail/simulation-detail.component.css
+++ b/frontend/src/app/simulations/simulation-detail/simulation-detail.component.css
@@ -237,3 +237,78 @@
     font-size: 26px;
   }
 }
+
+.success-card {
+  padding: 16px 18px;
+  border-radius: 14px;
+  margin-top: 18px;
+  color: #bbf7d0;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: rgba(22, 163, 74, 0.18);
+  font-weight: 600;
+}
+
+.export-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.export-section p {
+  margin: -8px 0 0;
+  color: #cbd5e1;
+}
+
+.export-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.export-button {
+  padding: 11px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 800;
+  transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.export-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.export-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.export-button.primary {
+  color: #020617;
+  border: 1px solid #38bdf8;
+  background: #38bdf8;
+}
+
+.export-button.primary:hover:not(:disabled) {
+  background: #7dd3fc;
+}
+
+.export-button.secondary {
+  color: #e2e8f0;
+  border: 1px solid #475569;
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.export-button.secondary:hover:not(:disabled) {
+  border-color: #38bdf8;
+  background: rgba(30, 41, 59, 0.95);
+}
+
+@media (max-width: 720px) {
+  .export-actions {
+    flex-direction: column;
+  }
+
+  .export-button {
+    width: 100%;
+  }
+}

--- a/frontend/src/app/simulations/simulation-detail/simulation-detail.component.html
+++ b/frontend/src/app/simulations/simulation-detail/simulation-detail.component.html
@@ -33,6 +33,43 @@
       </span>
     </header>
 
+    <section class="section-block export-section">
+      <div>
+        <h2>Exports</h2>
+        <p>
+          Télécharge les résultats enregistrés de cette simulation au format CSV ou PDF.
+        </p>
+      </div>
+
+      <div class="export-actions">
+        <button
+          type="button"
+          class="export-button secondary"
+          (click)="exportSimulation('csv')"
+          [disabled]="exportLoading"
+        >
+          {{ exportLoading ? 'Export en cours...' : 'Exporter CSV' }}
+        </button>
+
+        <button
+          type="button"
+          class="export-button primary"
+          (click)="exportSimulation('pdf')"
+          [disabled]="exportLoading"
+        >
+          {{ exportLoading ? 'Export en cours...' : 'Exporter PDF' }}
+        </button>
+      </div>
+
+      <div *ngIf="exportSuccessMessage" class="success-card">
+        {{ exportSuccessMessage }}
+      </div>
+
+      <div *ngIf="exportErrorMessage" class="error-card">
+        {{ exportErrorMessage }}
+      </div>
+    </section>
+
     <section class="section-block">
       <h2>Contexte</h2>
 

--- a/frontend/src/app/simulations/simulation-detail/simulation-detail.component.ts
+++ b/frontend/src/app/simulations/simulation-detail/simulation-detail.component.ts
@@ -25,6 +25,10 @@ export class SimulationDetailComponent implements OnInit {
   orbitPlotPoints: OrbitPlotPoint[] = [];
   hohmannPlotData: HohmannPlotData | null = null;
 
+  exportLoading = false;
+  exportErrorMessage = '';
+  exportSuccessMessage = '';
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -82,6 +86,64 @@ export class SimulationDetailComponent implements OnInit {
 
   goBack(): void {
     this.location.back();
+  }
+
+  exportSimulation(format: 'csv' | 'pdf'): void {
+    if (!this.simulation || this.exportLoading) {
+      return;
+    }
+
+    this.exportLoading = true;
+    this.exportErrorMessage = '';
+    this.exportSuccessMessage = '';
+
+    const simulationId = this.simulation.id;
+    const filename = `simulation-${simulationId}.${format}`;
+
+    const exportRequest = format === 'csv'
+      ? this.simulationService.exportCsv(simulationId)
+      : this.simulationService.exportPdf(simulationId);
+
+    exportRequest.subscribe({
+      next: (blob) => {
+        this.exportLoading = false;
+        this.downloadBlob(blob, filename);
+
+        this.exportSuccessMessage =
+          `Export ${format.toUpperCase()} généré avec succès.`;
+      },
+      error: (error) => {
+        this.exportLoading = false;
+
+        if (error.status === 403) {
+          this.router.navigate(['/forbidden']);
+          return;
+        }
+
+        if (error.status === 404) {
+          this.exportErrorMessage = 'Simulation introuvable.';
+          return;
+        }
+
+        this.exportErrorMessage =
+          `Impossible de générer l’export ${format.toUpperCase()}.`;
+      }
+    });
+  }
+
+  private downloadBlob(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+
+    link.href = url;
+    link.download = filename;
+    link.style.display = 'none';
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    window.URL.revokeObjectURL(url);
   }
 
   getSimulationTypeLabel(): string {


### PR DESCRIPTION
## Résumé

Cette PR ajoute l’US19 : export des résultats de simulation aux formats CSV et PDF.

Elle permet à un utilisateur autorisé d’exporter les données enregistrées d’une simulation orbitale ou d’un transfert de Hohmann depuis le détail d’une simulation.

Les exports sont générés à la demande et ne modifient pas les données en base.

---

## Changements principaux

- Ajout d’un service d’export de simulation
- Ajout de l’interface `SimulationExportService`
- Ajout de l’implémentation `SimulationExportServiceImpl`
- Ajout du contrôleur `SimulationExportController`
- Ajout des endpoints :
  - `GET /api/simulations/{id}/export/csv`
  - `GET /api/simulations/{id}/export/pdf`
- Génération d’un export CSV à colonnes fixes
- Génération d’un rapport PDF standardisé avec OpenPDF `3.0.5`
- Ajout de la dépendance OpenPDF dans `pom.xml`
- Ajout des boutons frontend `Exporter CSV` et `Exporter PDF`
- Gestion du téléchargement côté navigateur
- Gestion des erreurs `403` et `404` côté interface
- Mise à jour du `README.md`
- Ajout de `docs/tests/US19-tests.md`

---

## Export CSV

Le CSV utilise un format unique à colonnes fixes afin de couvrir les simulations `ORBIT` et `HOHMANN`.

Colonnes exportées :

```text
simulationId;missionId;missionName;satelliteId;satelliteName;type;status;createdAt;createdBy;inputMassKg;inputAltitudeKm;inputInclinationDeg;inputEccentricity;targetAltitudeKm;orbitalPeriodMinutes;averageVelocityKmS;orbitShape;deltaV1MS;deltaV2MS;deltaVTotalMS;transferTimeMinutes
```

Le séparateur utilisé est `;` afin d’assurer une ouverture correcte dans Excel en environnement français.

Le fichier est encodé en UTF-8 avec BOM pour préserver les caractères accentués.

---

## Export PDF

Le PDF est généré avec OpenPDF `3.0.5`.

Le rapport contient :

- un titre ;
- la date de génération ;
- les métadonnées de la simulation ;
- un tableau des paramètres d’entrée ;
- un tableau des résultats calculés ;
- une mention indiquant que le rapport est généré automatiquement.

---

## Données exportées

Les exports contiennent les informations suivantes :

- identifiant de simulation ;
- mission associée ;
- satellite concerné ;
- type de simulation ;
- statut ;
- date de création ;
- auteur ;
- masse ;
- altitude initiale ;
- inclinaison ;
- excentricité ;
- altitude cible pour les simulations `HOHMANN` ;
- période orbitale, vitesse moyenne et forme d’orbite pour les simulations `ORBIT` ;
- delta V1, delta V2, delta V total et durée de transfert pour les simulations `HOHMANN`.

---

## Frontend

La page détail simulation affiche maintenant une section `Exports`.

Deux boutons sont disponibles :

- `Exporter CSV`
- `Exporter PDF`

Le téléchargement est déclenché directement depuis le navigateur.

Les erreurs sont gérées :

- `403` : redirection vers la page forbidden ;
- `404` : message `Simulation introuvable`.

---

## Sécurité

Les exports sont accessibles aux rôles suivants :

- ADMIN
- OPERATEUR
- LECTEUR

Les endpoints utilisent les règles existantes de sécurité sur `/api/simulations/**`.

---

## Règles métier

- L’export est généré uniquement à la demande.
- Chaque export correspond à une simulation précise.
- Les données exportées correspondent aux données persistées en base.
- L’export ne modifie pas la base de données.
- Un format CSV unique est utilisé pour `ORBIT` et `HOHMANN`.
- Un modèle PDF unique est utilisé pour tous les types de simulation.
- Le rôle `LECTEUR` peut exporter une simulation.

---

## Tests et validation

Backend :

```bash
./mvnw test
```

Résultat :

```text
BUILD SUCCESS
```

Frontend :

```bash
npm run build
```

Résultat :

```text
Application bundle generation complete
```

Validation manuelle réalisée :

- export CSV depuis Postman ;
- export PDF depuis Postman ;
- export CSV depuis le navigateur ;
- export PDF depuis le navigateur ;
- ouverture correcte du CSV dans Excel ;
- ouverture correcte du PDF ;
- test avec un utilisateur LECTEUR ;
- vérification des endpoints avec une simulation `ORBIT` ;
- vérification des endpoints avec une simulation `HOHMANN`.

---

## Hors périmètre

Cette PR ne couvre pas :

- personnalisation du modèle PDF ;
- export de plusieurs simulations en une seule opération ;
- envoi automatique des exports par email ;
- archivage automatique des exports ;
- génération planifiée de rapports ;
- signature numérique des PDF.

---

## Conclusion

L’US19 est terminée.

Les utilisateurs autorisés peuvent exporter une simulation précise aux formats CSV et PDF depuis le détail de simulation. Les fichiers générés reflètent les données enregistrées et ne modifient pas la base.