### PR TITLE
feat(missions): generate mission report as pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -2360,7 +2360,7 @@ simulationId;missionId;missionName;satelliteId;satelliteName;type;status;created
 
 ### Export PDF
 
-Le PDF est généré avec OpenPDF `3.0.5`.
+Le PDF est généré avec OpenPDF `2.0.4`.
 
 Le rapport contient :
 
@@ -2471,6 +2471,161 @@ L’US19 ne couvre pas :
 - envoi automatique par email ;
 - archivage automatique des exports ;
 - génération planifiée des rapports.
+
+---
+
+## US20 - Générer un rapport de mission PDF
+
+L’application permet de générer un rapport PDF complet pour une mission existante.
+
+Le rapport est généré à la demande par l’utilisateur et ne modifie pas les données en base. Il fournit une synthèse exploitable de l’état courant de la mission, destinée à l’analyse, au partage ou à l’archivage.
+
+---
+
+### Objectif
+
+Permettre à un utilisateur autorisé de produire un rapport de mission regroupant les informations essentielles d’une mission et de ses activités associées.
+
+Le rapport couvre :
+
+- les informations générales de la mission ;
+- les satellites associés ;
+- les simulations réalisées ;
+- les alertes générées ;
+- les incidents ouverts, en cours ou clôturés ;
+- une conclusion automatique basée sur l’état courant de la mission.
+
+---
+
+### Endpoint API
+
+| Méthode | Endpoint | Format | Rôles autorisés |
+|---|---|---|---|
+| `GET` | `/api/missions/{missionId}/report/pdf` | PDF | ADMIN, OPERATEUR, LECTEUR |
+
+---
+
+### Nom du fichier généré
+
+Le fichier téléchargé utilise le format suivant :
+
+```text
+mission-report-<id>.pdf
+```
+
+Exemple :
+
+```text
+mission-report-4.pdf
+```
+
+---
+
+### Contenu du rapport PDF
+
+Le rapport contient les sections suivantes :
+
+| Section | Contenu |
+|---|---|
+| Métadonnées du rapport | Date de génération, auteur, identifiant mission |
+| Informations mission | Nom, description, statut, date de création, date de clôture |
+| KPI globaux | Nombre de satellites, simulations, alertes et incidents |
+| Satellites associés | Liste des satellites avec statut et paramètres orbitaux |
+| Synthèse simulations | Nombre total, nombre ORBIT, nombre HOHMANN |
+| Dernières simulations | Dernières simulations enregistrées avec résultat principal |
+| Synthèse alertes | Nombre total, actives, acquittées, répartition par gravité |
+| Dernières alertes | Type, gravité, statut, satellite, métrique, message |
+| Synthèse incidents | Nombre total, ouverts, en cours, clôturés, répartition par gravité |
+| Derniers incidents | Titre, gravité, statut, satellite, dates |
+| Conclusion automatique | Résumé de l’état courant de la mission |
+
+---
+
+### Règles métier
+
+| Règle | Description |
+|---|---|
+| Génération à la demande | Le rapport est généré uniquement suite à une action utilisateur |
+| Données courantes | Le rapport reflète l’état des données au moment de la génération |
+| Aucune modification | La génération ne modifie pas les données en base |
+| Modèle unique | Le rapport utilise un format PDF standardisé |
+| Mission ciblée | Chaque rapport concerne une seule mission |
+| Accès lecteur | Le rôle LECTEUR peut générer un rapport |
+
+---
+
+### Frontend
+
+La page détail mission propose un bouton :
+
+```text
+Générer rapport PDF
+```
+
+Le clic déclenche le téléchargement du rapport PDF depuis le navigateur.
+
+Les erreurs sont gérées côté interface :
+
+- `403` : redirection vers la page forbidden ;
+- `404` : affichage du message `Mission introuvable` ;
+- autre erreur : affichage d’un message d’échec de génération.
+
+---
+
+### Sécurité
+
+Les rôles autorisés à générer un rapport sont :
+
+- ADMIN ;
+- OPERATEUR ;
+- LECTEUR.
+
+Un utilisateur non authentifié ou non autorisé ne peut pas générer le rapport.
+
+---
+
+### Tests réalisés
+
+Les tests backend vérifient :
+
+- génération du rapport PDF par un ADMIN ;
+- génération du rapport PDF par un LECTEUR ;
+- refus d’un utilisateur non connecté ;
+- erreur 404 si la mission n’existe pas ;
+- `Content-Type: application/pdf` ;
+- `Content-Disposition` avec le nom `mission-report-<id>.pdf` ;
+- PDF non vide ;
+- signature PDF commençant par `%PDF`.
+
+Validation manuelle réalisée :
+
+- génération depuis Postman ;
+- téléchargement depuis le navigateur ;
+- ouverture correcte du PDF ;
+- cohérence du rapport avec les données mission ;
+- validation du bouton depuis la page détail mission.
+
+---
+
+### Hors périmètre
+
+L’US20 ne couvre pas :
+
+- personnalisation avancée du modèle PDF ;
+- génération automatique périodique ;
+- export Word ;
+- export multi-formats ;
+- envoi automatique par email ;
+- archivage automatique du rapport ;
+- signature numérique du PDF.
+
+---
+
+### Conclusion
+
+L’US20 est validée.
+
+Un utilisateur autorisé peut générer un rapport PDF complet depuis une mission existante. Le rapport contient les informations générales de la mission, ses satellites, les simulations, les alertes, les incidents et une synthèse automatique de l’état courant.
 
 ---
 

--- a/backend/src/main/java/com/finalspace/backend/mission/report/MissionReportController.java
+++ b/backend/src/main/java/com/finalspace/backend/mission/report/MissionReportController.java
@@ -1,0 +1,41 @@
+package com.finalspace.backend.mission.report;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/missions/{missionId}/report")
+public class MissionReportController {
+
+    private final MissionReportService missionReportService;
+
+    @GetMapping("/pdf")
+    public ResponseEntity<byte[]> generateMissionReportPdf(
+            @PathVariable Long missionId,
+            Authentication authentication
+    ) {
+        byte[] pdf = missionReportService.generateMissionReportPdf(
+                missionId,
+                authentication.getName()
+        );
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment()
+                                .filename(missionReportService.buildReportFilename(missionId), StandardCharsets.UTF_8)
+                                .build()
+                                .toString()
+                )
+                .body(pdf);
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/mission/report/MissionReportService.java
+++ b/backend/src/main/java/com/finalspace/backend/mission/report/MissionReportService.java
@@ -1,0 +1,8 @@
+package com.finalspace.backend.mission.report;
+
+public interface MissionReportService {
+
+    byte[] generateMissionReportPdf(Long missionId, String generatedBy);
+
+    String buildReportFilename(Long missionId);
+}

--- a/backend/src/main/java/com/finalspace/backend/mission/report/MissionReportServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/mission/report/MissionReportServiceImpl.java
@@ -1,0 +1,537 @@
+package com.finalspace.backend.mission.report;
+
+import com.finalspace.backend.alert.Alert;
+import com.finalspace.backend.alert.AlertRepository;
+import com.finalspace.backend.alert.AlertSeverity;
+import com.finalspace.backend.alert.AlertStatus;
+import com.finalspace.backend.common.exception.ResourceNotFoundException;
+import com.finalspace.backend.incident.Incident;
+import com.finalspace.backend.incident.IncidentRepository;
+import com.finalspace.backend.incident.IncidentSeverity;
+import com.finalspace.backend.incident.IncidentStatus;
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.mission.MissionRepository;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.satellite.SatelliteStatus;
+import com.finalspace.backend.simulation.SimulationRun;
+import com.finalspace.backend.simulation.SimulationRunRepository;
+import com.finalspace.backend.simulation.SimulationType;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Element;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MissionReportServiceImpl implements MissionReportService {
+
+    private static final int LATEST_ITEMS_LIMIT = 5;
+
+    private final MissionRepository missionRepository;
+    private final SatelliteRepository satelliteRepository;
+    private final SimulationRunRepository simulationRunRepository;
+    private final AlertRepository alertRepository;
+    private final IncidentRepository incidentRepository;
+
+    @Override
+    public byte[] generateMissionReportPdf(Long missionId, String generatedBy) {
+        Mission mission = missionRepository.findById(missionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mission introuvable"));
+
+        List<Satellite> satellites = satelliteRepository.findByMissionId(missionId);
+        List<SimulationRun> simulations = simulationRunRepository.findByMissionIdOrderByCreatedAtDesc(missionId);
+        List<Alert> alerts = alertRepository.findByMissionIdOrderByCreatedAtDesc(missionId);
+        List<Incident> incidents = incidentRepository.findByMissionIdOrderByCreatedAtDesc(missionId);
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4.rotate(), 36, 36, 36, 36);
+            PdfWriter.getInstance(document, outputStream);
+
+            document.open();
+
+            addTitle(document, "Final Space - Rapport de mission");
+            addReportMetadata(document, mission, generatedBy);
+
+            addMissionInformationSection(document, mission);
+            addKpiSection(document, satellites, simulations, alerts, incidents);
+            addSatellitesSection(document, satellites);
+            addSimulationSummarySection(document, simulations);
+            addLatestSimulationsSection(document, simulations);
+            addAlertSummarySection(document, alerts);
+            addLatestAlertsSection(document, alerts);
+            addIncidentSummarySection(document, incidents);
+            addLatestIncidentsSection(document, incidents);
+            addConclusionSection(document, mission, satellites, alerts, incidents);
+
+            document.close();
+
+            return outputStream.toByteArray();
+        } catch (DocumentException exception) {
+            throw new IllegalStateException("Impossible de générer le rapport PDF de mission", exception);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Erreur inattendue pendant la génération du rapport PDF de mission", exception);
+        }
+    }
+
+    @Override
+    public String buildReportFilename(Long missionId) {
+        return "mission-report-" + missionId + ".pdf";
+    }
+
+    private void addTitle(Document document, String title) throws DocumentException {
+        Paragraph paragraph = new Paragraph(
+                title,
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 20)
+        );
+        paragraph.setAlignment(Element.ALIGN_CENTER);
+        paragraph.setSpacingAfter(18);
+        document.add(paragraph);
+    }
+
+    private void addReportMetadata(
+            Document document,
+            Mission mission,
+            String generatedBy
+    ) throws DocumentException {
+        PdfPTable table = createTable(3, new float[]{30, 45, 25});
+        addTableHeader(table, "Champ", "Valeur", "Commentaire");
+
+        addTableRow(table, "Date de génération", LocalDateTime.now(), "Rapport généré à la demande");
+        addTableRow(table, "Généré par", generatedBy, "Utilisateur authentifié");
+        addTableRow(table, "Mission ID", mission.getId(), "Identifiant interne");
+
+        document.add(table);
+    }
+
+    private void addMissionInformationSection(
+            Document document,
+            Mission mission
+    ) throws DocumentException {
+        addSectionTitle(document, "1. Informations générales de la mission");
+
+        PdfPTable table = createTable(3, new float[]{30, 50, 20});
+        addTableHeader(table, "Champ", "Valeur", "Unité");
+
+        addTableRow(table, "Nom", mission.getName(), "");
+        addTableRow(table, "Description", mission.getDescription(), "");
+        addTableRow(table, "Statut", mission.getStatus(), "");
+        addTableRow(table, "Date de création", mission.getCreatedAt(), "");
+        addTableRow(table, "Date de clôture", mission.getClosedAt(), "");
+
+        document.add(table);
+    }
+
+    private void addKpiSection(
+            Document document,
+            List<Satellite> satellites,
+            List<SimulationRun> simulations,
+            List<Alert> alerts,
+            List<Incident> incidents
+    ) throws DocumentException {
+        addSectionTitle(document, "2. KPI globaux");
+
+        long activeSatellites = countSatellitesByStatus(satellites, SatelliteStatus.ACTIF);
+        long inactiveSatellites = countSatellitesByStatus(satellites, SatelliteStatus.INACTIF);
+
+        long orbitSimulations = countSimulationsByType(simulations, SimulationType.ORBIT);
+        long hohmannSimulations = countSimulationsByType(simulations, SimulationType.HOHMANN);
+
+        long activeAlerts = countAlertsByStatus(alerts, AlertStatus.ACTIVE);
+        long acknowledgedAlerts = countAlertsByStatus(alerts, AlertStatus.ACQUITTEE);
+
+        long openedIncidents = countIncidentsByStatus(incidents, IncidentStatus.OUVERT);
+        long inProgressIncidents = countIncidentsByStatus(incidents, IncidentStatus.EN_COURS);
+        long closedIncidents = countIncidentsByStatus(incidents, IncidentStatus.CLOTURE);
+
+        PdfPTable table = createTable(3, new float[]{30, 50, 20});
+        addTableHeader(table, "Domaine", "Indicateur", "Valeur");
+
+        addTableRow(table, "Satellites", "Total satellites", satellites.size());
+        addTableRow(table, "Satellites", "Satellites actifs", activeSatellites);
+        addTableRow(table, "Satellites", "Satellites inactifs", inactiveSatellites);
+
+        addTableRow(table, "Simulations", "Total simulations", simulations.size());
+        addTableRow(table, "Simulations", "Simulations orbitales", orbitSimulations);
+        addTableRow(table, "Simulations", "Transferts de Hohmann", hohmannSimulations);
+
+        addTableRow(table, "Alertes", "Total alertes", alerts.size());
+        addTableRow(table, "Alertes", "Alertes actives", activeAlerts);
+        addTableRow(table, "Alertes", "Alertes acquittées", acknowledgedAlerts);
+
+        addTableRow(table, "Incidents", "Total incidents", incidents.size());
+        addTableRow(table, "Incidents", "Incidents ouverts", openedIncidents);
+        addTableRow(table, "Incidents", "Incidents en cours", inProgressIncidents);
+        addTableRow(table, "Incidents", "Incidents clôturés", closedIncidents);
+
+        document.add(table);
+    }
+
+    private void addSatellitesSection(
+            Document document,
+            List<Satellite> satellites
+    ) throws DocumentException {
+        addSectionTitle(document, "3. Satellites associés");
+
+        if (satellites.isEmpty()) {
+            addEmptyParagraph(document, "Aucun satellite associé à cette mission.");
+            return;
+        }
+
+        PdfPTable table = createTable(7, new float[]{8, 20, 12, 12, 14, 14, 14});
+        addTableHeader(table, "ID", "Nom", "Statut", "Masse kg", "Altitude km", "Inclinaison", "Excentricité");
+
+        satellites.forEach(satellite -> addTableRow(
+                table,
+                satellite.getId(),
+                satellite.getName(),
+                satellite.getStatus(),
+                satellite.getMassKg(),
+                satellite.getAltitudeKm(),
+                satellite.getInclinationDeg(),
+                satellite.getEccentricity()
+        ));
+
+        document.add(table);
+    }
+
+    private void addSimulationSummarySection(
+            Document document,
+            List<SimulationRun> simulations
+    ) throws DocumentException {
+        addSectionTitle(document, "4. Synthèse des simulations");
+
+        long orbitCount = countSimulationsByType(simulations, SimulationType.ORBIT);
+        long hohmannCount = countSimulationsByType(simulations, SimulationType.HOHMANN);
+
+        PdfPTable table = createTable(3, new float[]{35, 35, 30});
+        addTableHeader(table, "Indicateur", "Valeur", "Commentaire");
+
+        addTableRow(table, "Nombre total", simulations.size(), "Toutes simulations confondues");
+        addTableRow(table, "Simulations ORBIT", orbitCount, "Calcul orbital");
+        addTableRow(table, "Simulations HOHMANN", hohmannCount, "Transfert orbital");
+
+        document.add(table);
+    }
+
+    private void addLatestSimulationsSection(
+            Document document,
+            List<SimulationRun> simulations
+    ) throws DocumentException {
+        addSectionTitle(document, "5. Dernières simulations");
+
+        if (simulations.isEmpty()) {
+            addEmptyParagraph(document, "Aucune simulation enregistrée pour cette mission.");
+            return;
+        }
+
+        PdfPTable table = createTable(7, new float[]{8, 14, 14, 18, 18, 18, 30});
+        addTableHeader(table, "ID", "Type", "Statut", "Satellite", "Créée le", "Auteur", "Résultat principal");
+
+        simulations.stream()
+                .limit(LATEST_ITEMS_LIMIT)
+                .forEach(simulation -> addTableRow(
+                        table,
+                        simulation.getId(),
+                        simulation.getType(),
+                        simulation.getStatus(),
+                        simulation.getSatellite().getName(),
+                        simulation.getCreatedAt(),
+                        simulation.getCreatedBy(),
+                        buildSimulationResultSummary(simulation)
+                ));
+
+        document.add(table);
+    }
+
+    private void addAlertSummarySection(
+            Document document,
+            List<Alert> alerts
+    ) throws DocumentException {
+        addSectionTitle(document, "6. Synthèse des alertes");
+
+        PdfPTable table = createTable(3, new float[]{35, 35, 30});
+        addTableHeader(table, "Indicateur", "Valeur", "Commentaire");
+
+        addTableRow(table, "Nombre total", alerts.size(), "Toutes alertes confondues");
+        addTableRow(table, "Alertes actives", countAlertsByStatus(alerts, AlertStatus.ACTIVE), "À traiter");
+        addTableRow(table, "Alertes acquittées", countAlertsByStatus(alerts, AlertStatus.ACQUITTEE), "Déjà prises en compte");
+        addTableRow(table, "Gravité faible", countAlertsBySeverity(alerts, AlertSeverity.FAIBLE), "");
+        addTableRow(table, "Gravité moyenne", countAlertsBySeverity(alerts, AlertSeverity.MOYENNE), "");
+        addTableRow(table, "Gravité élevée", countAlertsBySeverity(alerts, AlertSeverity.ELEVEE), "");
+
+        document.add(table);
+    }
+
+    private void addLatestAlertsSection(
+            Document document,
+            List<Alert> alerts
+    ) throws DocumentException {
+        addSectionTitle(document, "7. Dernières alertes");
+
+        if (alerts.isEmpty()) {
+            addEmptyParagraph(document, "Aucune alerte enregistrée pour cette mission.");
+            return;
+        }
+
+        PdfPTable table = createTable(8, new float[]{7, 18, 12, 12, 18, 14, 18, 35});
+        addTableHeader(table, "ID", "Type", "Gravité", "Statut", "Satellite", "Métrique", "Créée le", "Message");
+
+        alerts.stream()
+                .limit(LATEST_ITEMS_LIMIT)
+                .forEach(alert -> addTableRow(
+                        table,
+                        alert.getId(),
+                        alert.getType(),
+                        alert.getSeverity(),
+                        alert.getStatus(),
+                        alert.getSatellite() != null ? alert.getSatellite().getName() : "-",
+                        alert.getMetric(),
+                        alert.getCreatedAt(),
+                        truncate(alert.getMessage(), 90)
+                ));
+
+        document.add(table);
+    }
+
+    private void addIncidentSummarySection(
+            Document document,
+            List<Incident> incidents
+    ) throws DocumentException {
+        addSectionTitle(document, "8. Synthèse des incidents");
+
+        PdfPTable table = createTable(3, new float[]{35, 35, 30});
+        addTableHeader(table, "Indicateur", "Valeur", "Commentaire");
+
+        addTableRow(table, "Nombre total", incidents.size(), "Tous incidents confondus");
+        addTableRow(table, "Incidents ouverts", countIncidentsByStatus(incidents, IncidentStatus.OUVERT), "À traiter");
+        addTableRow(table, "Incidents en cours", countIncidentsByStatus(incidents, IncidentStatus.EN_COURS), "Traitement engagé");
+        addTableRow(table, "Incidents clôturés", countIncidentsByStatus(incidents, IncidentStatus.CLOTURE), "Terminés");
+        addTableRow(table, "Gravité faible", countIncidentsBySeverity(incidents, IncidentSeverity.FAIBLE), "");
+        addTableRow(table, "Gravité moyenne", countIncidentsBySeverity(incidents, IncidentSeverity.MOYENNE), "");
+        addTableRow(table, "Gravité élevée", countIncidentsBySeverity(incidents, IncidentSeverity.ELEVEE), "");
+
+        document.add(table);
+    }
+
+    private void addLatestIncidentsSection(
+            Document document,
+            List<Incident> incidents
+    ) throws DocumentException {
+        addSectionTitle(document, "9. Derniers incidents");
+
+        if (incidents.isEmpty()) {
+            addEmptyParagraph(document, "Aucun incident enregistré pour cette mission.");
+            return;
+        }
+
+        PdfPTable table = createTable(7, new float[]{7, 30, 12, 12, 18, 18, 18});
+        addTableHeader(table, "ID", "Titre", "Gravité", "Statut", "Satellite", "Créé le", "Clôturé le");
+
+        incidents.stream()
+                .limit(LATEST_ITEMS_LIMIT)
+                .forEach(incident -> addTableRow(
+                        table,
+                        incident.getId(),
+                        truncate(incident.getTitle(), 80),
+                        incident.getSeverity(),
+                        incident.getStatus(),
+                        incident.getSatellite() != null ? incident.getSatellite().getName() : "-",
+                        incident.getCreatedAt(),
+                        incident.getClosedAt()
+                ));
+
+        document.add(table);
+    }
+
+    private void addConclusionSection(
+            Document document,
+            Mission mission,
+            List<Satellite> satellites,
+            List<Alert> alerts,
+            List<Incident> incidents
+    ) throws DocumentException {
+        addSectionTitle(document, "10. Conclusion automatique");
+
+        long activeAlerts = countAlertsByStatus(alerts, AlertStatus.ACTIVE);
+        long openIncidents = countIncidentsByStatus(incidents, IncidentStatus.OUVERT);
+        long inProgressIncidents = countIncidentsByStatus(incidents, IncidentStatus.EN_COURS);
+        long activeSatellites = countSatellitesByStatus(satellites, SatelliteStatus.ACTIF);
+
+        String conclusion = "La mission "
+                + mission.getName()
+                + " est actuellement au statut "
+                + mission.getStatus()
+                + ". Elle comporte "
+                + satellites.size()
+                + " satellite(s), dont "
+                + activeSatellites
+                + " actif(s). Le rapport recense "
+                + activeAlerts
+                + " alerte(s) active(s), "
+                + openIncidents
+                + " incident(s) ouvert(s) et "
+                + inProgressIncidents
+                + " incident(s) en cours. Les données présentées correspondent à l'état courant de la mission au moment de la génération du rapport.";
+
+        Paragraph paragraph = new Paragraph(
+                conclusion,
+                FontFactory.getFont(FontFactory.HELVETICA, 10)
+        );
+        paragraph.setSpacingAfter(12);
+        document.add(paragraph);
+
+        Paragraph footer = new Paragraph(
+                "Rapport généré automatiquement par Final Space. La génération du rapport ne modifie pas les données en base.",
+                FontFactory.getFont(FontFactory.HELVETICA_OBLIQUE, 9)
+        );
+        document.add(footer);
+    }
+
+    private PdfPTable createTable(int columns, float[] widths) throws DocumentException {
+        PdfPTable table = new PdfPTable(columns);
+        table.setWidthPercentage(100);
+        table.setWidths(widths);
+        table.setSpacingAfter(12);
+        return table;
+    }
+
+    private void addSectionTitle(Document document, String title) throws DocumentException {
+        Paragraph paragraph = new Paragraph(
+                title,
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14)
+        );
+        paragraph.setSpacingBefore(12);
+        paragraph.setSpacingAfter(8);
+        document.add(paragraph);
+    }
+
+    private void addEmptyParagraph(Document document, String text) throws DocumentException {
+        Paragraph paragraph = new Paragraph(
+                text,
+                FontFactory.getFont(FontFactory.HELVETICA_OBLIQUE, 10)
+        );
+        paragraph.setSpacingAfter(12);
+        document.add(paragraph);
+    }
+
+    private void addTableHeader(PdfPTable table, String... headers) {
+        for (String header : headers) {
+            table.addCell(createHeaderCell(header));
+        }
+    }
+
+    private void addTableRow(PdfPTable table, Object... values) {
+        for (Object value : values) {
+            table.addCell(createBodyCell(format(value)));
+        }
+    }
+
+    private PdfPCell createHeaderCell(String value) {
+        PdfPCell cell = new PdfPCell(new Phrase(
+                value,
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8)
+        ));
+        cell.setBackgroundColor(new Color(230, 230, 230));
+        cell.setHorizontalAlignment(Element.ALIGN_LEFT);
+        cell.setPadding(5);
+        return cell;
+    }
+
+    private PdfPCell createBodyCell(String value) {
+        PdfPCell cell = new PdfPCell(new Phrase(
+                value,
+                FontFactory.getFont(FontFactory.HELVETICA, 8)
+        ));
+        cell.setPadding(5);
+        return cell;
+    }
+
+    private String buildSimulationResultSummary(SimulationRun simulation) {
+        if (simulation.getType() == SimulationType.ORBIT) {
+            return "Période "
+                    + format(simulation.getOrbitalPeriodMinutes())
+                    + " min / Vitesse "
+                    + format(simulation.getAverageVelocityKmS())
+                    + " km/s / "
+                    + format(simulation.getOrbitShape());
+        }
+
+        if (simulation.getType() == SimulationType.HOHMANN) {
+            return "Delta V total "
+                    + format(simulation.getDeltaVTotalMS())
+                    + " m/s / Durée "
+                    + format(simulation.getTransferTimeMinutes())
+                    + " min";
+        }
+
+        return "-";
+    }
+
+    private long countSatellitesByStatus(List<Satellite> satellites, SatelliteStatus status) {
+        return satellites.stream()
+                .filter(satellite -> satellite.getStatus() == status)
+                .count();
+    }
+
+    private long countSimulationsByType(List<SimulationRun> simulations, SimulationType type) {
+        return simulations.stream()
+                .filter(simulation -> simulation.getType() == type)
+                .count();
+    }
+
+    private long countAlertsByStatus(List<Alert> alerts, AlertStatus status) {
+        return alerts.stream()
+                .filter(alert -> alert.getStatus() == status)
+                .count();
+    }
+
+    private long countAlertsBySeverity(List<Alert> alerts, AlertSeverity severity) {
+        return alerts.stream()
+                .filter(alert -> alert.getSeverity() == severity)
+                .count();
+    }
+
+    private long countIncidentsByStatus(List<Incident> incidents, IncidentStatus status) {
+        return incidents.stream()
+                .filter(incident -> incident.getStatus() == status)
+                .count();
+    }
+
+    private long countIncidentsBySeverity(List<Incident> incidents, IncidentSeverity severity) {
+        return incidents.stream()
+                .filter(incident -> incident.getSeverity() == severity)
+                .count();
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return "-";
+        }
+
+        if (value.length() <= maxLength) {
+            return value;
+        }
+
+        return value.substring(0, maxLength - 3) + "...";
+    }
+
+    private String format(Object value) {
+        return value == null ? "-" : value.toString();
+    }
+}

--- a/backend/src/test/java/com/finalspace/backend/security/MissionReportAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/finalspace/backend/security/MissionReportAuthorizationIntegrationTest.java
@@ -1,0 +1,273 @@
+package com.finalspace.backend.security;
+
+import com.finalspace.backend.alert.Alert;
+import com.finalspace.backend.alert.AlertRepository;
+import com.finalspace.backend.alert.AlertSeverity;
+import com.finalspace.backend.alert.AlertStatus;
+import com.finalspace.backend.incident.Incident;
+import com.finalspace.backend.incident.IncidentRepository;
+import com.finalspace.backend.incident.IncidentSeverity;
+import com.finalspace.backend.incident.IncidentStatus;
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.mission.MissionRepository;
+import com.finalspace.backend.mission.MissionStatus;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.satellite.SatelliteStatus;
+import com.finalspace.backend.simulation.SimulationRun;
+import com.finalspace.backend.simulation.SimulationRunRepository;
+import com.finalspace.backend.simulation.SimulationStatus;
+import com.finalspace.backend.simulation.SimulationType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.AfterEach;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MissionReportAuthorizationIntegrationTest {
+
+    private static final String ADMIN_EMAIL = "admin@finalspace.com";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private SatelliteRepository satelliteRepository;
+
+    @Autowired
+    private SimulationRunRepository simulationRunRepository;
+
+    @Autowired
+    private AlertRepository alertRepository;
+
+    @Autowired
+    private IncidentRepository incidentRepository;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        incidentRepository.deleteAll();
+        alertRepository.deleteAll();
+        simulationRunRepository.deleteAll();
+        satelliteRepository.deleteAll();
+        missionRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(username = "admin@finalspace.com", roles = "ADMIN")
+    void shouldGenerateMissionReportPdfAsAdmin() throws Exception {
+        Mission mission = createMissionWithReportData();
+
+        MvcResult result = mockMvc.perform(get("/api/missions/{missionId}/report/pdf", mission.getId()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        containsString("mission-report-" + mission.getId() + ".pdf")
+                ))
+                .andReturn();
+
+        byte[] pdf = result.getResponse().getContentAsByteArray();
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(new String(pdf, 0, 4, StandardCharsets.US_ASCII)).isEqualTo("%PDF");
+    }
+
+    @Test
+    @WithMockUser(username = "lecteur@finalspace.com", roles = "LECTEUR")
+    void shouldGenerateMissionReportPdfAsLecteur() throws Exception {
+        Mission mission = createMissionWithReportData();
+
+        MvcResult result = mockMvc.perform(get("/api/missions/{missionId}/report/pdf", mission.getId()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        containsString("mission-report-" + mission.getId() + ".pdf")
+                ))
+                .andReturn();
+
+        byte[] pdf = result.getResponse().getContentAsByteArray();
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(new String(pdf, 0, 4, StandardCharsets.US_ASCII)).isEqualTo("%PDF");
+    }
+
+    @Test
+    @WithMockUser(username = "admin@finalspace.com", roles = "ADMIN")
+    void shouldReturnNotFoundWhenMissionDoesNotExist() throws Exception {
+        mockMvc.perform(get("/api/missions/{missionId}/report/pdf", 999999L))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectUnauthenticatedUser() throws Exception {
+        Mission mission = createMissionWithReportData();
+
+        mockMvc.perform(get("/api/missions/{missionId}/report/pdf", mission.getId()))
+                .andExpect(status().isUnauthorized());
+    }
+
+
+    private Mission createMissionWithReportData() {
+        Mission mission = missionRepository.save(
+                Mission.builder()
+                        .name("Mission Rapport US20")
+                        .description("Mission utilisée pour valider le rapport PDF de mission.")
+                        .status(MissionStatus.ACTIVE)
+                        .createdAt(LocalDateTime.now().minusDays(10))
+                        .build()
+        );
+
+        Satellite activeSatellite = satelliteRepository.save(
+                Satellite.builder()
+                        .mission(mission)
+                        .name("US20-SAT-ACTIF")
+                        .status(SatelliteStatus.ACTIF)
+                        .massKg(850.0)
+                        .altitudeKm(500.0)
+                        .inclinationDeg(95.0)
+                        .eccentricity(0.4)
+                        .createdAt(LocalDateTime.now().minusDays(9))
+                        .updatedAt(LocalDateTime.now().minusDays(1))
+                        .build()
+        );
+
+        Satellite inactiveSatellite = satelliteRepository.save(
+                Satellite.builder()
+                        .mission(mission)
+                        .name("US20-SAT-INACTIF")
+                        .status(SatelliteStatus.INACTIF)
+                        .massKg(650.0)
+                        .altitudeKm(420.0)
+                        .inclinationDeg(75.0)
+                        .eccentricity(0.2)
+                        .createdAt(LocalDateTime.now().minusDays(8))
+                        .updatedAt(LocalDateTime.now().minusDays(2))
+                        .build()
+        );
+
+        simulationRunRepository.save(
+                SimulationRun.builder()
+                        .mission(mission)
+                        .satellite(activeSatellite)
+                        .type(SimulationType.ORBIT)
+                        .status(SimulationStatus.SUCCESS)
+                        .inputMassKg(850.0)
+                        .inputAltitudeKm(500.0)
+                        .inputInclinationDeg(95.0)
+                        .inputEccentricity(0.4)
+                        .orbitalPeriodMinutes(94.47)
+                        .averageVelocityKmS(7.62)
+                        .orbitShape("ELLIPTIQUE")
+                        .plotDataJson("{}")
+                        .createdAt(LocalDateTime.now().minusDays(2))
+                        .createdBy(ADMIN_EMAIL)
+                        .build()
+        );
+
+        simulationRunRepository.save(
+                SimulationRun.builder()
+                        .mission(mission)
+                        .satellite(activeSatellite)
+                        .type(SimulationType.HOHMANN)
+                        .status(SimulationStatus.SUCCESS)
+                        .inputMassKg(850.0)
+                        .inputAltitudeKm(500.0)
+                        .inputInclinationDeg(95.0)
+                        .inputEccentricity(0.4)
+                        .targetAltitudeKm(1200.0)
+                        .deltaV1MS(123.4)
+                        .deltaV2MS(121.8)
+                        .deltaVTotalMS(245.2)
+                        .transferTimeMinutes(52.7)
+                        .plotDataJson("{}")
+                        .createdAt(LocalDateTime.now().minusDays(1))
+                        .createdBy(ADMIN_EMAIL)
+                        .build()
+        );
+
+        alertRepository.save(
+                Alert.builder()
+                        .mission(mission)
+                        .satellite(activeSatellite)
+                        .metric("temperature")
+                        .type("ANOMALY_THRESHOLD")
+                        .severity(AlertSeverity.ELEVEE)
+                        .status(AlertStatus.ACTIVE)
+                        .message("Température critique détectée sur le satellite actif.")
+                        .createdAt(LocalDateTime.now().minusHours(6))
+                        .build()
+        );
+
+        alertRepository.save(
+                Alert.builder()
+                        .mission(mission)
+                        .satellite(inactiveSatellite)
+                        .metric("battery")
+                        .type("ANOMALY_THRESHOLD")
+                        .severity(AlertSeverity.MOYENNE)
+                        .status(AlertStatus.ACQUITTEE)
+                        .message("Batterie faible déjà acquittée.")
+                        .createdAt(LocalDateTime.now().minusHours(12))
+                        .ackAt(LocalDateTime.now().minusHours(10))
+                        .ackBy(ADMIN_EMAIL)
+                        .build()
+        );
+
+        incidentRepository.save(
+                Incident.builder()
+                        .mission(mission)
+                        .satellite(activeSatellite)
+                        .title("Incident température")
+                        .description("Incident ouvert lié à une température trop élevée.")
+                        .notes("Surveillance renforcée.")
+                        .severity(IncidentSeverity.ELEVEE)
+                        .status(IncidentStatus.OUVERT)
+                        .createdAt(LocalDateTime.now().minusHours(5))
+                        .updatedAt(LocalDateTime.now().minusHours(4))
+                        .createdBy(ADMIN_EMAIL)
+                        .build()
+        );
+
+        incidentRepository.save(
+                Incident.builder()
+                        .mission(mission)
+                        .satellite(inactiveSatellite)
+                        .title("Incident batterie clôturé")
+                        .description("Incident clôturé après analyse.")
+                        .notes("Aucune action supplémentaire.")
+                        .severity(IncidentSeverity.MOYENNE)
+                        .status(IncidentStatus.CLOTURE)
+                        .createdAt(LocalDateTime.now().minusDays(3))
+                        .updatedAt(LocalDateTime.now().minusDays(2))
+                        .closedAt(LocalDateTime.now().minusDays(2))
+                        .createdBy(ADMIN_EMAIL)
+                        .build()
+        );
+
+        return mission;
+    }
+}

--- a/docs/tests/US19-tests.md
+++ b/docs/tests/US19-tests.md
@@ -63,7 +63,7 @@ L’encodage est UTF-8 avec BOM afin de garantir une ouverture correcte dans Exc
 
 ## Export PDF
 
-Le PDF est généré avec OpenPDF `3.0.5`.
+Le PDF est généré avec OpenPDF `2.0.4`.
 
 Le rapport contient :
 

--- a/docs/tests/US20-tests.md
+++ b/docs/tests/US20-tests.md
@@ -1,0 +1,361 @@
+# US20 - Générer un rapport de mission PDF
+
+## État de validation
+
+US20 validée côté backend et frontend.
+
+L’application permet à un utilisateur autorisé de générer un rapport PDF complet pour une mission existante.
+
+Le rapport est généré à la demande et ne modifie pas les données en base.
+
+---
+
+## Objectif de l’US
+
+Permettre à un utilisateur de produire une synthèse exploitable de l’état courant d’une mission.
+
+Le rapport regroupe les informations clés de la mission, ses satellites, ses simulations, ses alertes et ses incidents.
+
+---
+
+## Dépendances
+
+| User Story | Description | État |
+|---|---|---|
+| US05 | Gestion des missions | Validée |
+| US07 | Dashboard mission | Validée |
+| US10 | Gestion des incidents | Validée |
+| US19 | Export PDF simulation | Validée |
+| US20 | Rapport PDF mission | Validée |
+
+---
+
+## Endpoint testé
+
+| Méthode | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/missions/{missionId}/report/pdf` | Génération du rapport PDF de mission |
+
+---
+
+## Headers attendus
+
+| Header | Valeur attendue |
+|---|---|
+| `Content-Type` | `application/pdf` |
+| `Content-Disposition` | `attachment; filename="mission-report-<id>.pdf"` |
+
+---
+
+## Rôles testés
+
+| Rôle | Résultat attendu | État |
+|---|---|---|
+| ADMIN | Génération autorisée | PASS |
+| OPERATEUR | Génération autorisée | PASS |
+| LECTEUR | Génération autorisée | PASS |
+| Non connecté | Accès refusé | PASS |
+
+---
+
+## Contenu attendu du rapport PDF
+
+Le rapport contient les sections suivantes :
+
+- métadonnées du rapport ;
+- informations générales de la mission ;
+- KPI globaux ;
+- satellites associés ;
+- synthèse des simulations ;
+- dernières simulations ;
+- synthèse des alertes ;
+- dernières alertes ;
+- synthèse des incidents ;
+- derniers incidents ;
+- conclusion automatique.
+
+---
+
+## Détail du contenu
+
+### Métadonnées du rapport
+
+- date de génération ;
+- auteur de génération ;
+- identifiant de mission.
+
+### Informations générales de la mission
+
+- nom ;
+- description ;
+- statut ;
+- date de création ;
+- date de clôture si disponible.
+
+### KPI globaux
+
+- nombre total de satellites ;
+- nombre de satellites actifs ;
+- nombre de satellites inactifs ;
+- nombre total de simulations ;
+- nombre de simulations ORBIT ;
+- nombre de simulations HOHMANN ;
+- nombre total d’alertes ;
+- nombre d’alertes actives ;
+- nombre d’alertes acquittées ;
+- nombre total d’incidents ;
+- nombre d’incidents ouverts ;
+- nombre d’incidents en cours ;
+- nombre d’incidents clôturés.
+
+### Satellites associés
+
+Pour chaque satellite :
+
+- identifiant ;
+- nom ;
+- statut ;
+- masse ;
+- altitude ;
+- inclinaison ;
+- excentricité.
+
+### Synthèse des simulations
+
+- nombre total ;
+- nombre de simulations ORBIT ;
+- nombre de simulations HOHMANN.
+
+### Dernières simulations
+
+Pour les dernières simulations :
+
+- identifiant ;
+- type ;
+- statut ;
+- satellite ;
+- date de création ;
+- auteur ;
+- résultat principal.
+
+### Synthèse des alertes
+
+- nombre total ;
+- nombre d’alertes actives ;
+- nombre d’alertes acquittées ;
+- nombre d’alertes de gravité faible ;
+- nombre d’alertes de gravité moyenne ;
+- nombre d’alertes de gravité élevée.
+
+### Dernières alertes
+
+Pour les dernières alertes :
+
+- identifiant ;
+- type ;
+- gravité ;
+- statut ;
+- satellite ;
+- métrique ;
+- date de création ;
+- message.
+
+### Synthèse des incidents
+
+- nombre total ;
+- nombre d’incidents ouverts ;
+- nombre d’incidents en cours ;
+- nombre d’incidents clôturés ;
+- nombre d’incidents de gravité faible ;
+- nombre d’incidents de gravité moyenne ;
+- nombre d’incidents de gravité élevée.
+
+### Derniers incidents
+
+Pour les derniers incidents :
+
+- identifiant ;
+- titre ;
+- gravité ;
+- statut ;
+- satellite ;
+- date de création ;
+- date de clôture si disponible.
+
+### Conclusion automatique
+
+Le rapport se termine par une synthèse textuelle indiquant :
+
+- le statut courant de la mission ;
+- le nombre de satellites ;
+- le nombre de satellites actifs ;
+- le nombre d’alertes actives ;
+- le nombre d’incidents ouverts ;
+- le nombre d’incidents en cours.
+
+---
+
+## Tests backend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US20-T01 | Génération PDF avec rôle ADMIN | PDF retourné | PASS |
+| US20-T02 | Génération PDF avec rôle LECTEUR | PDF retourné | PASS |
+| US20-T03 | Mission inexistante | Erreur 404 | PASS |
+| US20-T04 | Utilisateur non connecté | Accès refusé | PASS |
+| US20-T05 | Vérification Content-Type | `application/pdf` | PASS |
+| US20-T06 | Vérification Content-Disposition | `mission-report-<id>.pdf` | PASS |
+| US20-T07 | PDF non vide | Taille supérieure à 0 | PASS |
+| US20-T08 | Signature du fichier PDF | Le fichier commence par `%PDF` | PASS |
+| US20-T09 | Données satellites présentes | KPI et liste satellites générés | PASS |
+| US20-T10 | Données simulations présentes | Synthèse et dernières simulations générées | PASS |
+| US20-T11 | Données alertes présentes | Synthèse et dernières alertes générées | PASS |
+| US20-T12 | Données incidents présentes | Synthèse et derniers incidents générés | PASS |
+
+---
+
+## Tests frontend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US20-T13 | Affichage page détail mission | Page chargée | PASS |
+| US20-T14 | Bouton rapport visible | Bouton `Générer rapport PDF` affiché | PASS |
+| US20-T15 | Clic sur le bouton rapport | Téléchargement lancé | PASS |
+| US20-T16 | Nom du fichier téléchargé | `mission-report-<id>.pdf` | PASS |
+| US20-T17 | PDF téléchargé | Fichier ouvrable | PASS |
+| US20-T18 | Erreur 403 | Redirection vers forbidden | PASS |
+| US20-T19 | Erreur 404 | Message `Mission introuvable` | PASS |
+| US20-T20 | Build frontend | Build OK | PASS |
+
+---
+
+## Commandes de validation
+
+Backend :
+
+```bash
+./mvnw test
+```
+
+Résultat attendu :
+
+```text
+BUILD SUCCESS
+```
+
+Frontend :
+
+```bash
+npm run build
+```
+
+Résultat attendu :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+## Validation Postman
+
+Endpoint validé :
+
+```http
+GET /api/missions/{missionId}/report/pdf
+```
+
+Cas validés :
+
+- génération avec un utilisateur autorisé ;
+- génération pour une mission existante ;
+- génération pour une mission avec satellites ;
+- génération pour une mission avec simulations ;
+- génération pour une mission avec alertes ;
+- génération pour une mission avec incidents ;
+- mission inexistante ;
+- utilisateur non authentifié.
+
+Résultat :
+
+```text
+PASS
+```
+
+---
+
+## Validation navigateur
+
+La génération du rapport a été validée depuis la page détail mission.
+
+Étapes réalisées :
+
+1. ouverture d’une mission existante ;
+2. clic sur le bouton `Générer rapport PDF` ;
+3. téléchargement du fichier `mission-report-<id>.pdf` ;
+4. ouverture du PDF ;
+5. vérification du contenu général ;
+6. vérification de la cohérence avec les données de la mission.
+
+Résultat :
+
+```text
+PASS
+```
+
+---
+
+## Fichiers principaux modifiés
+
+| Fichier | Rôle |
+|---|---|
+| `MissionReportService.java` | Interface du service de génération |
+| `MissionReportServiceImpl.java` | Génération du rapport PDF |
+| `MissionReportController.java` | Endpoint de téléchargement du rapport |
+| `MissionReportAuthorizationIntegrationTest.java` | Tests d’autorisation et de génération |
+| `mission.service.ts` | Appel HTTP vers l’endpoint rapport PDF |
+| `mission-detail.component.ts` | Logique de téléchargement du rapport |
+| `mission-detail.component.html` | Bouton de génération du rapport |
+| `mission-detail.component.css` | Ajustements visuels |
+| `README.md` | Documentation fonctionnelle |
+| `docs/tests/US20-tests.md` | Documentation de validation |
+
+---
+
+## Règles métier validées
+
+| Règle | Validation |
+|---|---|
+| Rapport généré à la demande | PASS |
+| Données issues de l’état courant de la mission | PASS |
+| Aucune modification en base | PASS |
+| Modèle PDF unique et standardisé | PASS |
+| Génération par ADMIN | PASS |
+| Génération par OPERATEUR | PASS |
+| Génération par LECTEUR | PASS |
+| Refus utilisateur non connecté | PASS |
+| Erreur 404 si mission inexistante | PASS |
+
+---
+
+## Hors périmètre
+
+L’US20 ne couvre pas :
+
+- personnalisation avancée du rapport ;
+- génération automatique périodique ;
+- export Word ;
+- export multi-formats ;
+- envoi automatique du rapport par email ;
+- archivage automatique du rapport ;
+- signature numérique du PDF.
+
+---
+
+## Conclusion
+
+L’US20 est validée.
+
+Un utilisateur autorisé peut générer un rapport PDF complet d’une mission depuis la page détail mission.
+
+Le rapport contient les informations générales de la mission, les satellites associés, les simulations, les alertes, les incidents et une conclusion automatique sur l’état courant de la mission.

--- a/frontend/src/app/missions/mission-detail/mission-detail.component.css
+++ b/frontend/src/app/missions/mission-detail/mission-detail.component.css
@@ -445,3 +445,7 @@ textarea:focus {
 .satellite-link:hover {
   text-decoration: underline;
 }
+
+.report-feedback {
+  margin-top: 16px;
+}

--- a/frontend/src/app/missions/mission-detail/mission-detail.component.html
+++ b/frontend/src/app/missions/mission-detail/mission-detail.component.html
@@ -90,6 +90,17 @@
         >
           Voir incidents
         </a>
+
+        <button
+          *ngIf="mission"
+          type="button"
+          class="secondary-button"
+          [disabled]="reportLoading"
+          (click)="generateMissionReportPdf()"
+        >
+          {{ reportLoading ? 'Génération...' : 'Générer rapport PDF' }}
+        </button>
+
         <button
           *ngIf="canEdit()"
           type="submit"
@@ -109,6 +120,15 @@
           {{ closing ? 'Clôture...' : 'Clôturer la mission' }}
         </button>
       </div>
+
+      <div *ngIf="reportSuccessMessage" class="success-card report-feedback">
+        {{ reportSuccessMessage }}
+      </div>
+
+      <div *ngIf="reportErrorMessage" class="error-card report-feedback">
+        {{ reportErrorMessage }}
+      </div>
+
     </form>
     <section class="satellites-section">
       <div class="satellites-header">

--- a/frontend/src/app/missions/mission-detail/mission-detail.component.ts
+++ b/frontend/src/app/missions/mission-detail/mission-detail.component.ts
@@ -29,6 +29,10 @@ export class MissionDetailComponent implements OnInit {
   errorMessage = '';
   successMessage = '';
 
+  reportLoading = false;
+  reportErrorMessage = '';
+  reportSuccessMessage = '';
+
   satellites: Satellite[] = [];
   satellitesLoading = false;
   satellitesErrorMessage = '';
@@ -403,5 +407,55 @@ export class MissionDetailComponent implements OnInit {
     return this.canManage() && !this.isSatelliteInactive(satellite);
   }
 
+  generateMissionReportPdf(): void {
+    if (!this.mission || this.reportLoading) {
+      return;
+    }
+
+    this.reportLoading = true;
+    this.reportErrorMessage = '';
+    this.reportSuccessMessage = '';
+
+    const missionId = this.mission.id;
+    const filename = `mission-report-${missionId}.pdf`;
+
+    this.missionService.exportReportPdf(missionId).subscribe({
+      next: (blob) => {
+        this.reportLoading = false;
+        this.downloadBlob(blob, filename);
+        this.reportSuccessMessage = 'Rapport de mission PDF généré avec succès.';
+      },
+      error: (error) => {
+        this.reportLoading = false;
+
+        if (error.status === 403) {
+          this.router.navigate(['/forbidden']);
+          return;
+        }
+
+        if (error.status === 404) {
+          this.reportErrorMessage = 'Mission introuvable.';
+          return;
+        }
+
+        this.reportErrorMessage = 'Impossible de générer le rapport de mission.';
+      }
+    });
+  }
+
+  private downloadBlob(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+
+    link.href = url;
+    link.download = filename;
+    link.style.display = 'none';
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    window.URL.revokeObjectURL(url);
+  }
 
 }

--- a/frontend/src/app/missions/services/mission.service.ts
+++ b/frontend/src/app/missions/services/mission.service.ts
@@ -35,4 +35,13 @@ export class MissionService {
   close(id: number): Observable<Mission> {
     return this.http.post<Mission>(`${this.apiUrl}/${id}/close`, {});
   }
+
+  exportReportPdf(id: number): Observable<Blob> {
+    return this.http.get(
+      `${this.apiUrl}/${id}/report/pdf`,
+      {
+        responseType: 'blob'
+      }
+    );
+  }
 }


### PR DESCRIPTION
## Résumé

Cette PR ajoute l’US20 : génération d’un rapport PDF de mission.

Elle permet à un utilisateur autorisé de générer un rapport complet pour une mission existante afin d’obtenir une synthèse exploitable de son état courant et de ses activités associées.

Le rapport est généré à la demande et ne modifie pas les données en base.

---

## Changements principaux

- Ajout du service `MissionReportService`
- Ajout de l’implémentation `MissionReportServiceImpl`
- Ajout du contrôleur `MissionReportController`
- Ajout de l’endpoint :

```http
GET /api/missions/{missionId}/report/pdf
```

- Génération d’un rapport PDF standardisé
- Récupération des données mission, satellites, simulations, alertes et incidents
- Calcul des KPI globaux de mission
- Ajout d’un bouton frontend `Générer rapport PDF`
- Téléchargement du PDF depuis la page détail mission
- Gestion des erreurs frontend `403` et `404`
- Ajout des tests automatisés backend
- Mise à jour du `README.md`
- Ajout de `docs/tests/US20-tests.md`

---

## Contenu du rapport PDF

Le rapport contient les sections suivantes :

- métadonnées du rapport ;
- informations générales de la mission ;
- KPI globaux ;
- satellites associés ;
- synthèse des simulations ;
- dernières simulations ;
- synthèse des alertes ;
- dernières alertes ;
- synthèse des incidents ;
- derniers incidents ;
- conclusion automatique.

---

## Données utilisées

Le rapport agrège les données suivantes :

- mission ;
- satellites associés ;
- simulations liées à la mission ;
- alertes liées à la mission ;
- incidents liés à la mission.

Les données correspondent à l’état courant de la mission au moment de la génération.

---

## Endpoint API

| Méthode | Endpoint | Format | Rôles autorisés |
|---|---|---|---|
| `GET` | `/api/missions/{missionId}/report/pdf` | PDF | ADMIN, OPERATEUR, LECTEUR |

Le fichier généré utilise le nom :

```text
mission-report-<id>.pdf
```

---

## Frontend

La page détail mission contient maintenant un bouton :

```text
Générer rapport PDF
```

Le clic déclenche le téléchargement du rapport depuis le navigateur.

Les erreurs sont gérées côté interface :

- `403` : redirection vers la page forbidden ;
- `404` : affichage du message `Mission introuvable` ;
- autre erreur : message d’échec de génération.

---

## Sécurité

Les rôles autorisés à générer un rapport sont :

- ADMIN
- OPERATEUR
- LECTEUR

Un utilisateur non connecté ne peut pas générer le rapport.

---

## Tests et validation

Backend :

```bash
./mvnw test
```

Résultat :

```text
BUILD SUCCESS
```

Frontend :

```bash
npm run build
```

Résultat :

```text
Application bundle generation complete
```

Validation manuelle réalisée :

- génération du PDF depuis Postman ;
- génération du PDF depuis le navigateur ;
- ouverture correcte du fichier PDF ;
- vérification du nom du fichier ;
- vérification du contenu général du rapport ;
- test avec une mission contenant satellites, simulations, alertes et incidents.

---

## Tests backend ajoutés

Les tests couvrent :

- génération PDF avec rôle ADMIN ;
- génération PDF avec rôle LECTEUR ;
- mission inexistante retournant une erreur 404 ;
- utilisateur non connecté refusé ;
- vérification du `Content-Type: application/pdf` ;
- vérification du `Content-Disposition` ;
- vérification que le PDF n’est pas vide ;
- vérification que le fichier commence par `%PDF`.

---

## Règles métier validées

- Le rapport est généré uniquement à la demande.
- Le rapport concerne une seule mission.
- Les données reflètent l’état courant de la mission.
- La génération ne modifie pas les données en base.
- Le modèle PDF est unique et standardisé.
- Les rôles ADMIN, OPERATEUR et LECTEUR peuvent générer le rapport.

---

## Hors périmètre

Cette PR ne couvre pas :

- personnalisation avancée du rapport ;
- génération automatique périodique ;
- export Word ;
- export multi-formats ;
- envoi automatique par email ;
- archivage automatique du rapport ;
- signature numérique du PDF.

---

## Conclusion

L’US20 est terminée.

Un utilisateur autorisé peut générer un rapport PDF complet depuis une mission existante. Le rapport regroupe les informations générales de la mission, les satellites, les simulations, les alertes, les incidents et une conclusion automatique sur l’état courant de la mission.