### PR TITLE
feat(telemetry): export telemetry reports as csv and pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -2621,11 +2621,229 @@ L’US20 ne couvre pas :
 
 ---
 
-### Conclusion
+## US21 - Exporter un rapport de télémétrie CSV/PDF
 
-L’US20 est validée.
+L’application permet d’exporter un rapport de télémétrie pour un satellite existant.
 
-Un utilisateur autorisé peut générer un rapport PDF complet depuis une mission existante. Le rapport contient les informations générales de la mission, ses satellites, les simulations, les alertes, les incidents et une synthèse automatique de l’état courant.
+Le rapport est généré à la demande par l’utilisateur et ne modifie pas les données en base. Il permet d’analyser, partager ou archiver les mesures de télémétrie associées à un satellite et à sa mission.
+
+---
+
+### Objectif
+
+Permettre à un utilisateur autorisé d’exporter les données de télémétrie d’un satellite, avec les anomalies et alertes associées.
+
+Le rapport peut être généré en deux formats :
+
+- CSV pour l’exploitation externe des données ;
+- PDF pour le partage, l’analyse ou l’archivage.
+
+---
+
+### Endpoints API
+
+| Méthode | Endpoint | Format | Rôles autorisés |
+|---|---|---|---|
+| `GET` | `/api/satellites/{satelliteId}/telemetry/report/csv` | CSV | ADMIN, OPERATEUR, LECTEUR |
+| `GET` | `/api/satellites/{satelliteId}/telemetry/report/pdf` | PDF | ADMIN, OPERATEUR, LECTEUR |
+
+---
+
+### Paramètres disponibles
+
+| Paramètre | Type | Obligatoire | Description |
+|---|---|---|---|
+| `metric` | `string` | Oui | Métrique à exporter. Peut être répétée pour exporter plusieurs métriques |
+| `from` | `Instant` | Non | Date de début de la période |
+| `to` | `Instant` | Non | Date de fin de la période |
+
+Exemple multi-métriques :
+
+```http
+GET /api/satellites/3/telemetry/report/csv?metric=temperature&metric=battery
+```
+
+Exemple avec période :
+
+```http
+GET /api/satellites/3/telemetry/report/pdf?metric=temperature&from=2026-01-01T10:00:00Z&to=2026-01-01T11:00:00Z
+```
+
+---
+
+### Noms des fichiers générés
+
+CSV :
+
+```text
+telemetry-report-<satelliteId>.csv
+```
+
+PDF :
+
+```text
+telemetry-report-<satelliteId>.pdf
+```
+
+---
+
+### Contenu du rapport CSV
+
+Le fichier CSV contient les colonnes suivantes :
+
+```text
+missionId;missionName;satelliteId;satelliteName;timestamp;metric;value;anomalyFlag;anomalyType;anomalySeverity;anomalyMessage
+```
+
+| Colonne | Description |
+|---|---|
+| `missionId` | Identifiant de la mission |
+| `missionName` | Nom de la mission |
+| `satelliteId` | Identifiant du satellite |
+| `satelliteName` | Nom du satellite |
+| `timestamp` | Date et heure de la mesure |
+| `metric` | Métrique mesurée |
+| `value` | Valeur mesurée |
+| `anomalyFlag` | Indique si une anomalie est associée au point |
+| `anomalyType` | Type d’anomalie détectée |
+| `anomalySeverity` | Gravité de l’anomalie |
+| `anomalyMessage` | Message descriptif de l’anomalie |
+
+Le fichier CSV utilise :
+
+- encodage UTF-8 avec BOM ;
+- séparateur `;` ;
+- fin de ligne CRLF.
+
+---
+
+### Contenu du rapport PDF
+
+Le rapport PDF contient les sections suivantes :
+
+| Section | Contenu |
+|---|---|
+| Métadonnées du rapport | Date de génération, auteur, identifiant satellite |
+| Informations générales | Mission, satellite, statut, paramètres orbitaux |
+| Périmètre du rapport | Métriques, période, nombre de points, anomalies et alertes |
+| Synthèse des métriques | Nombre de points, minimum, maximum et moyenne par métrique |
+| Synthèse des anomalies | Nombre total, répartition par type et gravité |
+| Dernières anomalies | Liste des anomalies principales |
+| Alertes associées | Synthèse des alertes liées aux données analysées |
+| Derniers points de télémétrie | Extrait des derniers points inclus |
+| Conclusion automatique | Synthèse de l’état des données exportées |
+
+---
+
+### Règles métier
+
+| Règle | Description |
+|---|---|
+| Génération à la demande | L’export est lancé uniquement suite à une action utilisateur |
+| Données existantes | Les données exportées sont celles présentes en base |
+| Aucune modification | L’export n’altère pas les données de télémétrie |
+| Format standardisé | Le PDF utilise un modèle unique |
+| Export satellite | L’export concerne un seul satellite |
+| Export multi-métriques | Plusieurs métriques peuvent être exportées en une demande |
+| Période optionnelle | `from` et `to` permettent de filtrer les données |
+| Limite de volumétrie | L’export est limité à 10 000 points de télémétrie |
+
+---
+
+### Frontend
+
+La page détail satellite propose deux boutons dans la section télémétrie :
+
+```text
+Exporter CSV
+Exporter PDF
+```
+
+L’utilisateur peut :
+
+- sélectionner une ou plusieurs métriques ;
+- définir une période optionnelle ;
+- exporter les données affichées en CSV ;
+- exporter un rapport synthétique en PDF.
+
+Les erreurs sont gérées côté interface :
+
+- `403` : redirection vers la page forbidden ;
+- `404` : affichage du message `Satellite introuvable` ;
+- `400` : affichage du message `Filtres invalides pour le rapport de télémétrie` ;
+- autre erreur : affichage d’un message d’échec de génération.
+
+---
+
+### Sécurité
+
+Les rôles autorisés à exporter un rapport de télémétrie sont :
+
+- ADMIN ;
+- OPERATEUR ;
+- LECTEUR.
+
+Un utilisateur non authentifié ou non autorisé ne peut pas générer le rapport.
+
+---
+
+### Tests réalisés
+
+Les tests d’intégration JUnit / Spring Boot / MockMvc vérifient :
+
+- génération du rapport CSV par un ADMIN ;
+- génération du rapport CSV par un LECTEUR ;
+- génération du rapport PDF par un ADMIN ;
+- génération du rapport PDF par un LECTEUR ;
+- filtrage par métrique ;
+- filtrage par période ;
+- erreur 404 si le satellite n’existe pas ;
+- erreur 400 si aucune métrique n’est fournie ;
+- erreur 400 si la période est invalide ;
+- refus d’un utilisateur non connecté ;
+- présence des headers de téléchargement ;
+- fichier CSV non vide ;
+- fichier PDF non vide ;
+- signature PDF commençant par `%PDF`.
+
+Validation manuelle réalisée :
+
+- export CSV depuis Postman ;
+- export PDF depuis Postman ;
+- export CSV depuis le navigateur ;
+- export PDF depuis le navigateur ;
+- vérification du contenu CSV ;
+- ouverture correcte du PDF ;
+- vérification du build frontend.
+
+---
+
+### Commandes de validation
+
+Backend :
+
+```bash
+./mvnw test
+```
+
+Frontend :
+
+```bash
+npm run build
+```
+
+---
+
+### Hors périmètre
+
+L’US21 ne couvre pas :
+
+- personnalisation avancée du contenu du rapport ;
+- export multi-satellites en une seule opération ;
+- génération automatique planifiée ;
+- envoi automatique par email ;
+- archivage automatique du rapport ;
+- signature numérique du PDF.
 
 ---
 

--- a/backend/src/main/java/com/finalspace/backend/telemetry/report/TelemetryReportController.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/report/TelemetryReportController.java
@@ -1,0 +1,75 @@
+package com.finalspace.backend.telemetry.report;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/satellites/{satelliteId}/telemetry/report")
+public class TelemetryReportController {
+
+    private final TelemetryReportService telemetryReportService;
+
+    @GetMapping("/csv")
+    public ResponseEntity<byte[]> exportCsv(
+            @PathVariable Long satelliteId,
+            @RequestParam(value = "metric") List<String> metrics,
+            @RequestParam(value = "from", required = false) Instant from,
+            @RequestParam(value = "to", required = false) Instant to
+    ) {
+        byte[] csv = telemetryReportService.generateTelemetryReportCsv(
+                satelliteId,
+                metrics,
+                from,
+                to
+        );
+
+        return ResponseEntity.ok()
+                .contentType(new MediaType("text", "csv", StandardCharsets.UTF_8))
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment()
+                                .filename(telemetryReportService.buildCsvFilename(satelliteId), StandardCharsets.UTF_8)
+                                .build()
+                                .toString()
+                )
+                .body(csv);
+    }
+
+    @GetMapping("/pdf")
+    public ResponseEntity<byte[]> exportPdf(
+            @PathVariable Long satelliteId,
+            @RequestParam(value = "metric") List<String> metrics,
+            @RequestParam(value = "from", required = false) Instant from,
+            @RequestParam(value = "to", required = false) Instant to,
+            Authentication authentication
+    ) {
+        byte[] pdf = telemetryReportService.generateTelemetryReportPdf(
+                satelliteId,
+                metrics,
+                from,
+                to,
+                authentication.getName()
+        );
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment()
+                                .filename(telemetryReportService.buildPdfFilename(satelliteId), StandardCharsets.UTF_8)
+                                .build()
+                                .toString()
+                )
+                .body(pdf);
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/report/TelemetryReportService.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/report/TelemetryReportService.java
@@ -1,0 +1,26 @@
+package com.finalspace.backend.telemetry.report;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface TelemetryReportService {
+
+    byte[] generateTelemetryReportCsv(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to
+    );
+
+    byte[] generateTelemetryReportPdf(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to,
+            String generatedBy
+    );
+
+    String buildCsvFilename(Long satelliteId);
+
+    String buildPdfFilename(Long satelliteId);
+}

--- a/backend/src/main/java/com/finalspace/backend/telemetry/report/TelemetryReportServiceImpl.java
+++ b/backend/src/main/java/com/finalspace/backend/telemetry/report/TelemetryReportServiceImpl.java
@@ -1,0 +1,751 @@
+package com.finalspace.backend.telemetry.report;
+
+import com.finalspace.backend.alert.Alert;
+import com.finalspace.backend.alert.AlertRepository;
+import com.finalspace.backend.alert.AlertSeverity;
+import com.finalspace.backend.alert.AlertStatus;
+import com.finalspace.backend.common.exception.BusinessException;
+import com.finalspace.backend.common.exception.ResourceNotFoundException;
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.telemetry.TelemetryPoint;
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomaly;
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomalySeverity;
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomalyType;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Element;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TelemetryReportServiceImpl implements TelemetryReportService {
+
+    private static final int MAX_EXPORT_POINTS = 10_000;
+    private static final int LATEST_ITEMS_LIMIT = 20;
+
+    private final SatelliteRepository satelliteRepository;
+    private final AlertRepository alertRepository;
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public byte[] generateTelemetryReportCsv(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to
+    ) {
+        ReportData data = loadReportData(satelliteId, metrics, from, to);
+        Map<TelemetryKey, List<TelemetryAnomaly>> anomaliesByPoint = groupAnomaliesByPoint(data.anomalies());
+
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("missionId;")
+                .append("missionName;")
+                .append("satelliteId;")
+                .append("satelliteName;")
+                .append("timestamp;")
+                .append("metric;")
+                .append("value;")
+                .append("anomalyFlag;")
+                .append("anomalyType;")
+                .append("anomalySeverity;")
+                .append("anomalyMessage")
+                .append("\r\n");
+
+        for (TelemetryPoint point : data.points()) {
+            List<TelemetryAnomaly> pointAnomalies = anomaliesByPoint.getOrDefault(
+                    new TelemetryKey(point.getMetric(), point.getTimestamp()),
+                    List.of()
+            );
+
+            csv.append(csvValue(data.mission().getId())).append(';')
+                    .append(csvValue(data.mission().getName())).append(';')
+                    .append(csvValue(data.satellite().getId())).append(';')
+                    .append(csvValue(data.satellite().getName())).append(';')
+                    .append(csvValue(point.getTimestamp())).append(';')
+                    .append(csvValue(point.getMetric())).append(';')
+                    .append(csvValue(point.getValue())).append(';')
+                    .append(csvValue(!pointAnomalies.isEmpty())).append(';')
+                    .append(csvValue(joinAnomalyTypes(pointAnomalies))).append(';')
+                    .append(csvValue(joinAnomalySeverities(pointAnomalies))).append(';')
+                    .append(csvValue(joinAnomalyMessages(pointAnomalies)))
+                    .append("\r\n");
+        }
+
+        return ("\uFEFF" + csv).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public byte[] generateTelemetryReportPdf(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to,
+            String generatedBy
+    ) {
+        ReportData data = loadReportData(satelliteId, metrics, from, to);
+        List<MetricStats> metricStats = buildMetricStats(data.points());
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4.rotate(), 36, 36, 36, 36);
+            PdfWriter.getInstance(document, outputStream);
+
+            document.open();
+
+            addTitle(document, "Final Space - Rapport de télémétrie");
+            addReportMetadata(document, data, generatedBy);
+            addMissionSatelliteSection(document, data);
+            addPeriodSection(document, data);
+            addMetricSummarySection(document, metricStats);
+            addAnomalySummarySection(document, data.anomalies());
+            addLatestAnomaliesSection(document, data.anomalies());
+            addAlertSummarySection(document, data.alerts());
+            addLatestTelemetryPointsSection(document, data.points());
+            addConclusionSection(document, data);
+
+            document.close();
+
+            return outputStream.toByteArray();
+        } catch (DocumentException exception) {
+            throw new IllegalStateException("Impossible de générer le rapport PDF de télémétrie", exception);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Erreur inattendue pendant la génération du rapport PDF de télémétrie", exception);
+        }
+    }
+
+    @Override
+    public String buildCsvFilename(Long satelliteId) {
+        return "telemetry-report-" + satelliteId + ".csv";
+    }
+
+    @Override
+    public String buildPdfFilename(Long satelliteId) {
+        return "telemetry-report-" + satelliteId + ".pdf";
+    }
+
+    private ReportData loadReportData(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to
+    ) {
+        Satellite satellite = satelliteRepository.findByIdWithMission(satelliteId)
+                .orElseThrow(() -> new ResourceNotFoundException("Satellite introuvable"));
+
+        Mission mission = satellite.getMission();
+
+        List<String> normalizedMetrics = normalizeMetrics(metrics);
+        validatePeriod(from, to);
+
+        List<TelemetryPoint> points = findTelemetryPoints(
+                satelliteId,
+                normalizedMetrics,
+                from,
+                to
+        );
+
+        if (points.size() > MAX_EXPORT_POINTS) {
+            throw new BusinessException("L'export de télémétrie est limité à " + MAX_EXPORT_POINTS + " points");
+        }
+
+        List<TelemetryAnomaly> anomalies = findTelemetryAnomalies(
+                satelliteId,
+                normalizedMetrics,
+                from,
+                to
+        );
+
+        List<Alert> alerts = findTelemetryAlerts(
+                mission.getId(),
+                satelliteId,
+                normalizedMetrics,
+                from,
+                to
+        );
+
+        return new ReportData(
+                mission,
+                satellite,
+                normalizedMetrics,
+                from,
+                to,
+                points,
+                anomalies,
+                alerts
+        );
+    }
+
+    private List<TelemetryPoint> findTelemetryPoints(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to
+    ) {
+        Query query = new Query();
+
+        query.addCriteria(
+                Criteria.where("satelliteId").is(satelliteId)
+                        .and("metric").in(metrics)
+        );
+
+        addTimestampCriteria(query, from, to);
+
+        query.with(Sort.by(Sort.Direction.ASC, "timestamp"));
+
+        return mongoTemplate.find(query, TelemetryPoint.class);
+    }
+
+    private List<TelemetryAnomaly> findTelemetryAnomalies(
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to
+    ) {
+        Query query = new Query();
+
+        query.addCriteria(
+                Criteria.where("satelliteId").is(satelliteId)
+                        .and("metric").in(metrics)
+        );
+
+        addTimestampCriteria(query, from, to);
+
+        query.with(Sort.by(Sort.Direction.DESC, "timestamp"));
+
+        return mongoTemplate.find(query, TelemetryAnomaly.class);
+    }
+
+    private List<Alert> findTelemetryAlerts(
+            Long missionId,
+            Long satelliteId,
+            List<String> metrics,
+            Instant from,
+            Instant to
+    ) {
+        return alertRepository.findByMissionIdOrderByCreatedAtDesc(missionId)
+                .stream()
+                .filter(alert -> alert.getSatellite() != null)
+                .filter(alert -> Objects.equals(alert.getSatellite().getId(), satelliteId))
+                .filter(alert -> alert.getMetric() != null && metrics.contains(alert.getMetric()))
+                .filter(alert -> isAlertInPeriod(alert, from, to))
+                .toList();
+    }
+
+    private boolean isAlertInPeriod(Alert alert, Instant from, Instant to) {
+        Instant timestamp = alert.getTelemetryTimestamp();
+
+        if (timestamp == null) {
+            return true;
+        }
+
+        if (from != null && timestamp.isBefore(from)) {
+            return false;
+        }
+
+        return to == null || !timestamp.isAfter(to);
+    }
+
+    private void addTimestampCriteria(Query query, Instant from, Instant to) {
+        if (from == null && to == null) {
+            return;
+        }
+
+        Criteria timestampCriteria = Criteria.where("timestamp");
+
+        if (from != null) {
+            timestampCriteria = timestampCriteria.gte(from);
+        }
+
+        if (to != null) {
+            timestampCriteria = timestampCriteria.lte(to);
+        }
+
+        query.addCriteria(timestampCriteria);
+    }
+
+    private List<String> normalizeMetrics(List<String> metrics) {
+        if (metrics == null || metrics.isEmpty()) {
+            throw new BusinessException("Au moins une métrique est obligatoire");
+        }
+
+        List<String> normalizedMetrics = metrics.stream()
+                .flatMap(metric -> Arrays.stream(metric.split(",")))
+                .map(String::trim)
+                .filter(metric -> !metric.isBlank())
+                .distinct()
+                .toList();
+
+        if (normalizedMetrics.isEmpty()) {
+            throw new BusinessException("Au moins une métrique est obligatoire");
+        }
+
+        return normalizedMetrics;
+    }
+
+    private void validatePeriod(Instant from, Instant to) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new BusinessException("La date de début doit être antérieure à la date de fin");
+        }
+    }
+
+    private List<MetricStats> buildMetricStats(List<TelemetryPoint> points) {
+        Map<String, List<TelemetryPoint>> groupedByMetric = points.stream()
+                .collect(Collectors.groupingBy(TelemetryPoint::getMetric));
+
+        return groupedByMetric.entrySet()
+                .stream()
+                .map(entry -> {
+                    String metric = entry.getKey();
+                    List<Double> values = entry.getValue()
+                            .stream()
+                            .map(TelemetryPoint::getValue)
+                            .filter(Objects::nonNull)
+                            .toList();
+
+                    if (values.isEmpty()) {
+                        return new MetricStats(metric, entry.getValue().size(), null, null, null);
+                    }
+
+                    double min = values.stream().mapToDouble(Double::doubleValue).min().orElse(0);
+                    double max = values.stream().mapToDouble(Double::doubleValue).max().orElse(0);
+                    double average = values.stream().mapToDouble(Double::doubleValue).average().orElse(0);
+
+                    return new MetricStats(metric, entry.getValue().size(), min, max, average);
+                })
+                .sorted(Comparator.comparing(MetricStats::metric))
+                .toList();
+    }
+
+    private Map<TelemetryKey, List<TelemetryAnomaly>> groupAnomaliesByPoint(List<TelemetryAnomaly> anomalies) {
+        return anomalies.stream()
+                .collect(Collectors.groupingBy(anomaly -> new TelemetryKey(
+                        anomaly.getMetric(),
+                        anomaly.getTimestamp()
+                )));
+    }
+
+    private String joinAnomalyTypes(List<TelemetryAnomaly> anomalies) {
+        return anomalies.stream()
+                .map(anomaly -> anomaly.getType().name())
+                .distinct()
+                .collect(Collectors.joining(" | "));
+    }
+
+    private String joinAnomalySeverities(List<TelemetryAnomaly> anomalies) {
+        return anomalies.stream()
+                .map(anomaly -> anomaly.getSeverity().name())
+                .distinct()
+                .collect(Collectors.joining(" | "));
+    }
+
+    private String joinAnomalyMessages(List<TelemetryAnomaly> anomalies) {
+        return anomalies.stream()
+                .map(TelemetryAnomaly::getMessage)
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.joining(" | "));
+    }
+
+    private void addTitle(Document document, String title) throws DocumentException {
+        Paragraph paragraph = new Paragraph(
+                title,
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 20)
+        );
+        paragraph.setAlignment(Element.ALIGN_CENTER);
+        paragraph.setSpacingAfter(18);
+        document.add(paragraph);
+    }
+
+    private void addReportMetadata(
+            Document document,
+            ReportData data,
+            String generatedBy
+    ) throws DocumentException {
+        PdfPTable table = createTable(3, new float[]{30, 45, 25});
+        addTableHeader(table, "Champ", "Valeur", "Commentaire");
+
+        addTableRow(table, "Date de génération", LocalDateTime.now(), "Rapport généré à la demande");
+        addTableRow(table, "Généré par", generatedBy, "Utilisateur authentifié");
+        addTableRow(table, "Satellite ID", data.satellite().getId(), "Identifiant interne");
+
+        document.add(table);
+    }
+
+    private void addMissionSatelliteSection(
+            Document document,
+            ReportData data
+    ) throws DocumentException {
+        addSectionTitle(document, "1. Informations générales");
+
+        PdfPTable table = createTable(3, new float[]{30, 50, 20});
+        addTableHeader(table, "Champ", "Valeur", "Unité");
+
+        addTableRow(table, "Mission", data.mission().getName() + " (#" + data.mission().getId() + ")", "");
+        addTableRow(table, "Statut mission", data.mission().getStatus(), "");
+        addTableRow(table, "Satellite", data.satellite().getName() + " (#" + data.satellite().getId() + ")", "");
+        addTableRow(table, "Statut satellite", data.satellite().getStatus(), "");
+        addTableRow(table, "Masse", data.satellite().getMassKg(), "kg");
+        addTableRow(table, "Altitude", data.satellite().getAltitudeKm(), "km");
+        addTableRow(table, "Inclinaison", data.satellite().getInclinationDeg(), "deg");
+        addTableRow(table, "Excentricité", data.satellite().getEccentricity(), "");
+
+        document.add(table);
+    }
+
+    private void addPeriodSection(
+            Document document,
+            ReportData data
+    ) throws DocumentException {
+        addSectionTitle(document, "2. Périmètre du rapport");
+
+        PdfPTable table = createTable(3, new float[]{30, 50, 20});
+        addTableHeader(table, "Champ", "Valeur", "Commentaire");
+
+        addTableRow(table, "Métriques analysées", String.join(", ", data.metrics()), "");
+        addTableRow(table, "Début", data.from(), "Filtre optionnel");
+        addTableRow(table, "Fin", data.to(), "Filtre optionnel");
+        addTableRow(table, "Points exportés", data.points().size(), "Limite " + MAX_EXPORT_POINTS);
+        addTableRow(table, "Anomalies associées", data.anomalies().size(), "");
+        addTableRow(table, "Alertes associées", data.alerts().size(), "");
+
+        document.add(table);
+    }
+
+    private void addMetricSummarySection(
+            Document document,
+            List<MetricStats> stats
+    ) throws DocumentException {
+        addSectionTitle(document, "3. Synthèse des métriques");
+
+        if (stats.isEmpty()) {
+            addEmptyParagraph(document, "Aucun point de télémétrie trouvé pour les filtres sélectionnés.");
+            return;
+        }
+
+        PdfPTable table = createTable(5, new float[]{25, 15, 20, 20, 20});
+        addTableHeader(table, "Métrique", "Points", "Minimum", "Maximum", "Moyenne");
+
+        stats.forEach(stat -> addTableRow(
+                table,
+                stat.metric(),
+                stat.count(),
+                stat.min(),
+                stat.max(),
+                stat.average()
+        ));
+
+        document.add(table);
+    }
+
+    private void addAnomalySummarySection(
+            Document document,
+            List<TelemetryAnomaly> anomalies
+    ) throws DocumentException {
+        addSectionTitle(document, "4. Synthèse des anomalies");
+
+        PdfPTable table = createTable(3, new float[]{35, 35, 30});
+        addTableHeader(table, "Indicateur", "Valeur", "Commentaire");
+
+        addTableRow(table, "Nombre total", anomalies.size(), "");
+        addTableRow(table, "THRESHOLD", countAnomaliesByType(anomalies, TelemetryAnomalyType.THRESHOLD), "Seuil dépassé");
+        addTableRow(table, "VARIATION", countAnomaliesByType(anomalies, TelemetryAnomalyType.VARIATION), "Variation brusque");
+        addTableRow(table, "MISSING", countAnomaliesByType(anomalies, TelemetryAnomalyType.MISSING), "Données manquantes");
+        addTableRow(table, "Gravité faible", countAnomaliesBySeverity(anomalies, TelemetryAnomalySeverity.FAIBLE), "");
+        addTableRow(table, "Gravité moyenne", countAnomaliesBySeverity(anomalies, TelemetryAnomalySeverity.MOYENNE), "");
+        addTableRow(table, "Gravité élevée", countAnomaliesBySeverity(anomalies, TelemetryAnomalySeverity.ELEVEE), "");
+
+        document.add(table);
+    }
+
+    private void addLatestAnomaliesSection(
+            Document document,
+            List<TelemetryAnomaly> anomalies
+    ) throws DocumentException {
+        addSectionTitle(document, "5. Dernières anomalies");
+
+        if (anomalies.isEmpty()) {
+            addEmptyParagraph(document, "Aucune anomalie associée aux filtres sélectionnés.");
+            return;
+        }
+
+        PdfPTable table = createTable(7, new float[]{18, 18, 16, 16, 16, 22, 40});
+        addTableHeader(table, "Date", "Métrique", "Type", "Gravité", "Valeur", "Règle", "Message");
+
+        anomalies.stream()
+                .limit(LATEST_ITEMS_LIMIT)
+                .forEach(anomaly -> addTableRow(
+                        table,
+                        anomaly.getTimestamp(),
+                        anomaly.getMetric(),
+                        anomaly.getType(),
+                        anomaly.getSeverity(),
+                        anomaly.getValue(),
+                        anomaly.getRuleName(),
+                        truncate(anomaly.getMessage(), 100)
+                ));
+
+        document.add(table);
+    }
+
+    private void addAlertSummarySection(
+            Document document,
+            List<Alert> alerts
+    ) throws DocumentException {
+        addSectionTitle(document, "6. Alertes associées");
+
+        PdfPTable table = createTable(3, new float[]{35, 35, 30});
+        addTableHeader(table, "Indicateur", "Valeur", "Commentaire");
+
+        addTableRow(table, "Nombre total", alerts.size(), "");
+        addTableRow(table, "Alertes actives", countAlertsByStatus(alerts, AlertStatus.ACTIVE), "À traiter");
+        addTableRow(table, "Alertes acquittées", countAlertsByStatus(alerts, AlertStatus.ACQUITTEE), "Déjà prises en compte");
+        addTableRow(table, "Gravité faible", countAlertsBySeverity(alerts, AlertSeverity.FAIBLE), "");
+        addTableRow(table, "Gravité moyenne", countAlertsBySeverity(alerts, AlertSeverity.MOYENNE), "");
+        addTableRow(table, "Gravité élevée", countAlertsBySeverity(alerts, AlertSeverity.ELEVEE), "");
+
+        document.add(table);
+    }
+
+    private void addLatestTelemetryPointsSection(
+            Document document,
+            List<TelemetryPoint> points
+    ) throws DocumentException {
+        addSectionTitle(document, "7. Derniers points de télémétrie");
+
+        if (points.isEmpty()) {
+            addEmptyParagraph(document, "Aucun point de télémétrie trouvé pour les filtres sélectionnés.");
+            return;
+        }
+
+        PdfPTable table = createTable(4, new float[]{28, 24, 24, 24});
+        addTableHeader(table, "Timestamp", "Métrique", "Valeur", "Import");
+
+        points.stream()
+                .sorted(Comparator.comparing(TelemetryPoint::getTimestamp).reversed())
+                .limit(LATEST_ITEMS_LIMIT)
+                .forEach(point -> addTableRow(
+                        table,
+                        point.getTimestamp(),
+                        point.getMetric(),
+                        point.getValue(),
+                        point.getSourceImportId()
+                ));
+
+        document.add(table);
+    }
+
+    private void addConclusionSection(
+            Document document,
+            ReportData data
+    ) throws DocumentException {
+        addSectionTitle(document, "8. Conclusion automatique");
+
+        long highAnomalies = countAnomaliesBySeverity(data.anomalies(), TelemetryAnomalySeverity.ELEVEE);
+        long activeAlerts = countAlertsByStatus(data.alerts(), AlertStatus.ACTIVE);
+
+        String conclusion = "Le rapport de télémétrie du satellite "
+                + data.satellite().getName()
+                + " couvre "
+                + data.points().size()
+                + " point(s) de mesure sur "
+                + data.metrics().size()
+                + " métrique(s). "
+                + data.anomalies().size()
+                + " anomalie(s) sont associées aux filtres sélectionnés, dont "
+                + highAnomalies
+                + " de gravité élevée. "
+                + activeAlerts
+                + " alerte(s) active(s) sont liées aux données analysées. "
+                + "Les données présentées correspondent aux données existantes en base au moment de la génération du rapport.";
+
+        Paragraph paragraph = new Paragraph(
+                conclusion,
+                FontFactory.getFont(FontFactory.HELVETICA, 10)
+        );
+        paragraph.setSpacingAfter(12);
+        document.add(paragraph);
+
+        Paragraph footer = new Paragraph(
+                "Rapport généré automatiquement par Final Space. La génération du rapport n'altère pas les données de télémétrie.",
+                FontFactory.getFont(FontFactory.HELVETICA_OBLIQUE, 9)
+        );
+        document.add(footer);
+    }
+
+    private long countAnomaliesByType(List<TelemetryAnomaly> anomalies, TelemetryAnomalyType type) {
+        return anomalies.stream()
+                .filter(anomaly -> anomaly.getType() == type)
+                .count();
+    }
+
+    private long countAnomaliesBySeverity(List<TelemetryAnomaly> anomalies, TelemetryAnomalySeverity severity) {
+        return anomalies.stream()
+                .filter(anomaly -> anomaly.getSeverity() == severity)
+                .count();
+    }
+
+    private long countAlertsByStatus(List<Alert> alerts, AlertStatus status) {
+        return alerts.stream()
+                .filter(alert -> alert.getStatus() == status)
+                .count();
+    }
+
+    private long countAlertsBySeverity(List<Alert> alerts, AlertSeverity severity) {
+        return alerts.stream()
+                .filter(alert -> alert.getSeverity() == severity)
+                .count();
+    }
+
+    private PdfPTable createTable(int columns, float[] widths) throws DocumentException {
+        PdfPTable table = new PdfPTable(columns);
+        table.setWidthPercentage(100);
+        table.setWidths(widths);
+        table.setSpacingAfter(12);
+        return table;
+    }
+
+    private void addSectionTitle(Document document, String title) throws DocumentException {
+        Paragraph paragraph = new Paragraph(
+                title,
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14)
+        );
+        paragraph.setSpacingBefore(12);
+        paragraph.setSpacingAfter(8);
+        document.add(paragraph);
+    }
+
+    private void addEmptyParagraph(Document document, String text) throws DocumentException {
+        Paragraph paragraph = new Paragraph(
+                text,
+                FontFactory.getFont(FontFactory.HELVETICA_OBLIQUE, 10)
+        );
+        paragraph.setSpacingAfter(12);
+        document.add(paragraph);
+    }
+
+    private void addTableHeader(PdfPTable table, String... headers) {
+        for (String header : headers) {
+            table.addCell(createHeaderCell(header));
+        }
+    }
+
+    private void addTableRow(PdfPTable table, Object... values) {
+        for (Object value : values) {
+            table.addCell(createBodyCell(format(value)));
+        }
+    }
+
+    private PdfPCell createHeaderCell(String value) {
+        PdfPCell cell = new PdfPCell(new Phrase(
+                value,
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8)
+        ));
+        cell.setBackgroundColor(new Color(230, 230, 230));
+        cell.setHorizontalAlignment(Element.ALIGN_LEFT);
+        cell.setPadding(5);
+        return cell;
+    }
+
+    private PdfPCell createBodyCell(String value) {
+        PdfPCell cell = new PdfPCell(new Phrase(
+                value,
+                FontFactory.getFont(FontFactory.HELVETICA, 8)
+        ));
+        cell.setPadding(5);
+        return cell;
+    }
+
+    private String csvValue(Object value) {
+        if (value == null) {
+            return "";
+        }
+
+        String text = value.toString();
+
+        if (
+                text.contains(";")
+                        || text.contains("\"")
+                        || text.contains("\n")
+                        || text.contains("\r")
+        ) {
+            return "\"" + text.replace("\"", "\"\"") + "\"";
+        }
+
+        return text;
+    }
+
+    private String format(Object value) {
+        if (value == null) {
+            return "-";
+        }
+
+        if (value instanceof Double doubleValue) {
+            return String.format(Locale.US, "%.3f", doubleValue);
+        }
+
+        return value.toString();
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return "-";
+        }
+
+        if (value.length() <= maxLength) {
+            return value;
+        }
+
+        return value.substring(0, maxLength - 3) + "...";
+    }
+
+    private record ReportData(
+            Mission mission,
+            Satellite satellite,
+            List<String> metrics,
+            Instant from,
+            Instant to,
+            List<TelemetryPoint> points,
+            List<TelemetryAnomaly> anomalies,
+            List<Alert> alerts
+    ) {
+    }
+
+    private record TelemetryKey(
+            String metric,
+            Instant timestamp
+    ) {
+    }
+
+    private record MetricStats(
+            String metric,
+            long count,
+            Double min,
+            Double max,
+            Double average
+    ) {
+    }
+}

--- a/backend/src/test/java/com/finalspace/backend/security/TelemetryReportAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/finalspace/backend/security/TelemetryReportAuthorizationIntegrationTest.java
@@ -1,0 +1,341 @@
+package com.finalspace.backend.security;
+
+import com.finalspace.backend.alert.Alert;
+import com.finalspace.backend.alert.AlertRepository;
+import com.finalspace.backend.alert.AlertSeverity;
+import com.finalspace.backend.alert.AlertStatus;
+import com.finalspace.backend.mission.Mission;
+import com.finalspace.backend.mission.MissionRepository;
+import com.finalspace.backend.mission.MissionStatus;
+import com.finalspace.backend.satellite.Satellite;
+import com.finalspace.backend.satellite.SatelliteRepository;
+import com.finalspace.backend.satellite.SatelliteStatus;
+import com.finalspace.backend.telemetry.TelemetryPoint;
+import com.finalspace.backend.telemetry.TelemetryPointRepository;
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomaly;
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomalyRepository;
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomalySeverity;
+import com.finalspace.backend.telemetry.anomaly.TelemetryAnomalyType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TelemetryReportAuthorizationIntegrationTest {
+
+    private static final String ADMIN_EMAIL = "admin@finalspace.com";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private SatelliteRepository satelliteRepository;
+
+    @Autowired
+    private AlertRepository alertRepository;
+
+    @Autowired
+    private TelemetryPointRepository telemetryPointRepository;
+
+    @Autowired
+    private TelemetryAnomalyRepository telemetryAnomalyRepository;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        telemetryAnomalyRepository.deleteAll();
+        telemetryPointRepository.deleteAll();
+        alertRepository.deleteAll();
+        satelliteRepository.deleteAll();
+        missionRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(username = ADMIN_EMAIL, roles = "ADMIN")
+    void shouldExportTelemetryReportCsvAsAdmin() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        MvcResult result = mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/csv", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("metric", "battery"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/csv"))
+                .andExpect(header().string(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        containsString("telemetry-report-" + satellite.getId() + ".csv")
+                ))
+                .andReturn();
+
+        String csv = result.getResponse().getContentAsString(StandardCharsets.UTF_8)
+                .replace("\uFEFF", "");
+
+        assertThat(csv).isNotBlank();
+        assertThat(csv).startsWith(
+                "missionId;missionName;satelliteId;satelliteName;timestamp;metric;value;anomalyFlag;anomalyType;anomalySeverity;anomalyMessage"
+        );
+        assertThat(csv).contains("temperature");
+        assertThat(csv).contains("battery");
+        assertThat(csv).contains("true");
+        assertThat(csv).contains("THRESHOLD");
+    }
+
+    @Test
+    @WithMockUser(username = "lecteur@finalspace.com", roles = "LECTEUR")
+    void shouldExportTelemetryReportCsvAsLecteur() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/csv", satellite.getId())
+                        .param("metric", "temperature"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/csv"))
+                .andExpect(header().string(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        containsString("telemetry-report-" + satellite.getId() + ".csv")
+                ));
+    }
+
+    @Test
+    @WithMockUser(username = ADMIN_EMAIL, roles = "ADMIN")
+    void shouldExportTelemetryReportPdfAsAdmin() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        MvcResult result = mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/pdf", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("metric", "battery"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PDF))
+                .andExpect(header().string(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        containsString("telemetry-report-" + satellite.getId() + ".pdf")
+                ))
+                .andReturn();
+
+        byte[] pdf = result.getResponse().getContentAsByteArray();
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(new String(pdf, 0, 4, StandardCharsets.US_ASCII)).isEqualTo("%PDF");
+    }
+
+    @Test
+    @WithMockUser(username = "lecteur@finalspace.com", roles = "LECTEUR")
+    void shouldExportTelemetryReportPdfAsLecteur() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        MvcResult result = mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/pdf", satellite.getId())
+                        .param("metric", "temperature"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PDF))
+                .andReturn();
+
+        byte[] pdf = result.getResponse().getContentAsByteArray();
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(new String(pdf, 0, 4, StandardCharsets.US_ASCII)).isEqualTo("%PDF");
+    }
+
+    @Test
+    @WithMockUser(username = ADMIN_EMAIL, roles = "ADMIN")
+    void shouldFilterTelemetryReportByMetric() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        MvcResult result = mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/csv", satellite.getId())
+                        .param("metric", "temperature"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String csv = result.getResponse().getContentAsString(StandardCharsets.UTF_8)
+                .replace("\uFEFF", "");
+
+        assertThat(csv).contains("temperature");
+        assertThat(csv).doesNotContain(";battery;");
+    }
+
+    @Test
+    @WithMockUser(username = ADMIN_EMAIL, roles = "ADMIN")
+    void shouldFilterTelemetryReportByPeriod() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        MvcResult result = mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/csv", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("from", "2026-01-01T10:05:00Z")
+                        .param("to", "2026-01-01T10:10:00Z"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String csv = result.getResponse().getContentAsString(StandardCharsets.UTF_8)
+                .replace("\uFEFF", "");
+
+        assertThat(csv).contains("2026-01-01T10:05:00Z");
+        assertThat(csv).contains("2026-01-01T10:10:00Z");
+        assertThat(csv).doesNotContain("2026-01-01T10:00:00Z");
+    }
+
+    @Test
+    @WithMockUser(username = ADMIN_EMAIL, roles = "ADMIN")
+    void shouldReturnNotFoundWhenSatelliteDoesNotExist() throws Exception {
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/pdf", 999999L)
+                        .param("metric", "temperature"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = ADMIN_EMAIL, roles = "ADMIN")
+    void shouldRejectMissingMetric() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/pdf", satellite.getId()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = ADMIN_EMAIL, roles = "ADMIN")
+    void shouldRejectInvalidPeriod() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/pdf", satellite.getId())
+                        .param("metric", "temperature")
+                        .param("from", "2026-01-02T10:00:00Z")
+                        .param("to", "2026-01-01T10:00:00Z"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldRejectUnauthenticatedUser() throws Exception {
+        Satellite satellite = createSatelliteWithTelemetryData();
+
+        mockMvc.perform(get("/api/satellites/{satelliteId}/telemetry/report/pdf", satellite.getId())
+                        .param("metric", "temperature"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private Satellite createSatelliteWithTelemetryData() {
+        Mission mission = missionRepository.save(
+                Mission.builder()
+                        .name("Mission télémétrie US21")
+                        .description("Mission utilisée pour valider le rapport de télémétrie.")
+                        .status(MissionStatus.ACTIVE)
+                        .createdAt(LocalDateTime.now().minusDays(10))
+                        .build()
+        );
+
+        Satellite satellite = satelliteRepository.save(
+                Satellite.builder()
+                        .mission(mission)
+                        .name("US21-SAT")
+                        .status(SatelliteStatus.ACTIF)
+                        .massKg(850.0)
+                        .altitudeKm(500.0)
+                        .inclinationDeg(95.0)
+                        .eccentricity(0.01)
+                        .createdAt(LocalDateTime.now().minusDays(9))
+                        .updatedAt(LocalDateTime.now().minusDays(1))
+                        .build()
+        );
+
+        telemetryPointRepository.save(
+                TelemetryPoint.builder()
+                        .missionId(mission.getId())
+                        .satelliteId(satellite.getId())
+                        .timestamp(Instant.parse("2026-01-01T10:00:00Z"))
+                        .metric("temperature")
+                        .value(40.0)
+                        .sourceImportId("import-us21")
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        telemetryPointRepository.save(
+                TelemetryPoint.builder()
+                        .missionId(mission.getId())
+                        .satelliteId(satellite.getId())
+                        .timestamp(Instant.parse("2026-01-01T10:05:00Z"))
+                        .metric("temperature")
+                        .value(62.0)
+                        .sourceImportId("import-us21")
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        telemetryPointRepository.save(
+                TelemetryPoint.builder()
+                        .missionId(mission.getId())
+                        .satelliteId(satellite.getId())
+                        .timestamp(Instant.parse("2026-01-01T10:10:00Z"))
+                        .metric("temperature")
+                        .value(85.0)
+                        .sourceImportId("import-us21")
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        telemetryPointRepository.save(
+                TelemetryPoint.builder()
+                        .missionId(mission.getId())
+                        .satelliteId(satellite.getId())
+                        .timestamp(Instant.parse("2026-01-01T10:05:00Z"))
+                        .metric("battery")
+                        .value(78.0)
+                        .sourceImportId("import-us21")
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        telemetryAnomalyRepository.save(
+                TelemetryAnomaly.builder()
+                        .missionId(mission.getId())
+                        .satelliteId(satellite.getId())
+                        .metric("temperature")
+                        .type(TelemetryAnomalyType.THRESHOLD)
+                        .severity(TelemetryAnomalySeverity.ELEVEE)
+                        .timestamp(Instant.parse("2026-01-01T10:10:00Z"))
+                        .value(85.0)
+                        .previousValue(62.0)
+                        .previousTimestamp(Instant.parse("2026-01-01T10:05:00Z"))
+                        .ruleName("TEMP_MAX")
+                        .thresholdUsed(80.0)
+                        .message("Valeur supérieure au seuil critique")
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        alertRepository.save(
+                Alert.builder()
+                        .mission(mission)
+                        .satellite(satellite)
+                        .metric("temperature")
+                        .type("ANOMALY_THRESHOLD")
+                        .severity(AlertSeverity.ELEVEE)
+                        .status(AlertStatus.ACTIVE)
+                        .message("Température critique détectée.")
+                        .createdAt(LocalDateTime.now().minusHours(1))
+                        .telemetryValue(85.0)
+                        .telemetryTimestamp(Instant.parse("2026-01-01T10:10:00Z"))
+                        .build()
+        );
+
+        return satellite;
+    }
+}

--- a/docs/tests/US21-tests.md
+++ b/docs/tests/US21-tests.md
@@ -1,0 +1,407 @@
+# US21 - Exporter un rapport de télémétrie CSV/PDF
+
+## État de validation
+
+US21 validée côté backend et frontend.
+
+L’application permet à un utilisateur autorisé d’exporter un rapport de télémétrie associé à un satellite existant.
+
+Le rapport peut être généré en CSV ou en PDF.
+
+---
+
+## Objectif de l’US
+
+Permettre à un utilisateur d’analyser, partager ou archiver les données mesurées d’un satellite.
+
+Le rapport de télémétrie fournit une vue synthétique ou détaillée des données mesurées, avec les anomalies et alertes associées.
+
+---
+
+## Dépendances
+
+| User Story | Description | État |
+|---|---|---|
+| US15 | Import de télémétrie CSV | Validée |
+| US16 | Visualisation de la télémétrie | Validée |
+| US17 | Détection d’anomalies | Validée |
+| US18 | Génération d’alertes depuis anomalies | Validée |
+| US21 | Export rapport télémétrie CSV/PDF | Validée |
+
+---
+
+## Endpoints testés
+
+| Méthode | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/satellites/{satelliteId}/telemetry/report/csv` | Export du rapport de télémétrie en CSV |
+| `GET` | `/api/satellites/{satelliteId}/telemetry/report/pdf` | Export du rapport de télémétrie en PDF |
+
+---
+
+## Paramètres testés
+
+| Paramètre | Type | Obligatoire | Exemple |
+|---|---|---|---|
+| `metric` | `string` | Oui | `temperature` |
+| `metric` répété | `string[]` | Non | `metric=temperature&metric=battery` |
+| `from` | `Instant` | Non | `2026-01-01T10:00:00Z` |
+| `to` | `Instant` | Non | `2026-01-01T11:00:00Z` |
+
+---
+
+## Headers attendus
+
+### CSV
+
+| Header | Valeur attendue |
+|---|---|
+| `Content-Type` | `text/csv` |
+| `Content-Disposition` | `attachment; filename="telemetry-report-<satelliteId>.csv"` |
+
+### PDF
+
+| Header | Valeur attendue |
+|---|---|
+| `Content-Type` | `application/pdf` |
+| `Content-Disposition` | `attachment; filename="telemetry-report-<satelliteId>.pdf"` |
+
+---
+
+## Rôles testés
+
+| Rôle | Résultat attendu | État |
+|---|---|---|
+| ADMIN | Export autorisé | PASS |
+| OPERATEUR | Export autorisé | PASS |
+| LECTEUR | Export autorisé | PASS |
+| Non connecté | Accès refusé | PASS |
+
+---
+
+## Contenu attendu du CSV
+
+Le fichier CSV contient les colonnes suivantes :
+
+```text
+missionId;missionName;satelliteId;satelliteName;timestamp;metric;value;anomalyFlag;anomalyType;anomalySeverity;anomalyMessage
+```
+
+Chaque ligne représente un point de télémétrie exporté.
+
+Les anomalies associées sont indiquées par :
+
+- `anomalyFlag` ;
+- `anomalyType` ;
+- `anomalySeverity` ;
+- `anomalyMessage`.
+
+---
+
+## Contenu attendu du PDF
+
+Le rapport PDF contient les sections suivantes :
+
+- métadonnées du rapport ;
+- informations générales mission / satellite ;
+- période couverte ;
+- métriques analysées ;
+- synthèse des métriques ;
+- statistiques par métrique ;
+- synthèse des anomalies ;
+- dernières anomalies ;
+- synthèse des alertes associées ;
+- derniers points de télémétrie ;
+- conclusion automatique.
+
+---
+
+## Détail du contenu PDF
+
+### Métadonnées du rapport
+
+- date de génération ;
+- utilisateur ayant généré le rapport ;
+- identifiant du satellite.
+
+### Informations générales
+
+- mission associée ;
+- statut de la mission ;
+- satellite concerné ;
+- statut du satellite ;
+- masse ;
+- altitude ;
+- inclinaison ;
+- excentricité.
+
+### Périmètre du rapport
+
+- métriques analysées ;
+- date de début si fournie ;
+- date de fin si fournie ;
+- nombre de points exportés ;
+- nombre d’anomalies associées ;
+- nombre d’alertes associées.
+
+### Synthèse des métriques
+
+Pour chaque métrique :
+
+- nombre de points ;
+- valeur minimale ;
+- valeur maximale ;
+- valeur moyenne.
+
+### Synthèse des anomalies
+
+Le rapport indique :
+
+- nombre total d’anomalies ;
+- nombre d’anomalies de type `THRESHOLD` ;
+- nombre d’anomalies de type `VARIATION` ;
+- nombre d’anomalies de type `MISSING` ;
+- nombre d’anomalies de gravité faible ;
+- nombre d’anomalies de gravité moyenne ;
+- nombre d’anomalies de gravité élevée.
+
+### Alertes associées
+
+Le rapport indique :
+
+- nombre total d’alertes ;
+- nombre d’alertes actives ;
+- nombre d’alertes acquittées ;
+- répartition par gravité.
+
+### Conclusion automatique
+
+Le rapport se termine par une synthèse textuelle indiquant :
+
+- le satellite concerné ;
+- le nombre de points analysés ;
+- le nombre de métriques ;
+- le nombre d’anomalies ;
+- le nombre d’anomalies de gravité élevée ;
+- le nombre d’alertes actives.
+
+---
+
+## Tests backend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US21-T01 | Export CSV avec rôle ADMIN | CSV retourné | PASS |
+| US21-T02 | Export CSV avec rôle LECTEUR | CSV retourné | PASS |
+| US21-T03 | Export PDF avec rôle ADMIN | PDF retourné | PASS |
+| US21-T04 | Export PDF avec rôle LECTEUR | PDF retourné | PASS |
+| US21-T05 | Export CSV multi-métriques | Les métriques demandées sont présentes | PASS |
+| US21-T06 | Filtrage CSV par métrique | Seule la métrique demandée est exportée | PASS |
+| US21-T07 | Filtrage CSV par période | Seuls les points de la période sont exportés | PASS |
+| US21-T08 | Satellite inexistant | Erreur 404 | PASS |
+| US21-T09 | Métrique absente | Erreur 400 | PASS |
+| US21-T10 | Période invalide `from > to` | Erreur 400 | PASS |
+| US21-T11 | Utilisateur non connecté | Accès refusé | PASS |
+| US21-T12 | Vérification Content-Type CSV | `text/csv` | PASS |
+| US21-T13 | Vérification Content-Type PDF | `application/pdf` | PASS |
+| US21-T14 | Vérification Content-Disposition CSV | `telemetry-report-<id>.csv` | PASS |
+| US21-T15 | Vérification Content-Disposition PDF | `telemetry-report-<id>.pdf` | PASS |
+| US21-T16 | CSV non vide | Taille supérieure à 0 | PASS |
+| US21-T17 | PDF non vide | Taille supérieure à 0 | PASS |
+| US21-T18 | Signature PDF | Le fichier commence par `%PDF` | PASS |
+| US21-T19 | Anomalie incluse dans CSV | `anomalyFlag=true` et type présent | PASS |
+| US21-T20 | Alerte associée prise en compte dans PDF | Synthèse alertes générée | PASS |
+
+---
+
+## Tests frontend réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US21-T21 | Affichage page détail satellite | Page chargée | PASS |
+| US21-T22 | Affichage section télémétrie | Section visible | PASS |
+| US21-T23 | Sélection d’une métrique | Métrique sélectionnée | PASS |
+| US21-T24 | Sélection de plusieurs métriques | Plusieurs métriques sélectionnées | PASS |
+| US21-T25 | Sélection d’une période | `from` et `to` pris en compte | PASS |
+| US21-T26 | Clic sur `Exporter CSV` | Téléchargement CSV lancé | PASS |
+| US21-T27 | Clic sur `Exporter PDF` | Téléchargement PDF lancé | PASS |
+| US21-T28 | Nom fichier CSV | `telemetry-report-<satelliteId>.csv` | PASS |
+| US21-T29 | Nom fichier PDF | `telemetry-report-<satelliteId>.pdf` | PASS |
+| US21-T30 | Fichier CSV téléchargé | Fichier ouvrable | PASS |
+| US21-T31 | Fichier PDF téléchargé | Fichier ouvrable | PASS |
+| US21-T32 | Erreur 403 | Redirection forbidden | PASS |
+| US21-T33 | Erreur 404 | Message `Satellite introuvable` | PASS |
+| US21-T34 | Erreur 400 | Message filtres invalides | PASS |
+| US21-T35 | Build frontend | Build OK | PASS |
+
+---
+
+## Tests Postman automatisés réalisés
+
+| ID | Scénario | Résultat attendu | État |
+|---|---|---|---|
+| US21-P01 | Export CSV | Status 200 | PASS |
+| US21-P02 | Export CSV | Header `text/csv` | PASS |
+| US21-P03 | Export CSV | Header `Content-Disposition` correct | PASS |
+| US21-P04 | Export CSV | Body non vide | PASS |
+| US21-P05 | Export CSV | Colonnes attendues présentes | PASS |
+| US21-P06 | Export CSV | Au moins une ligne de données | PASS |
+| US21-P07 | Export PDF | Status 200 | PASS |
+| US21-P08 | Export PDF | Header `application/pdf` | PASS |
+| US21-P09 | Export PDF | Header `Content-Disposition` correct | PASS |
+| US21-P10 | Export PDF | Réponse non vide | PASS |
+| US21-P11 | Satellite inexistant | Erreur 404 | PASS |
+| US21-P12 | Métrique manquante | Erreur 400 | PASS |
+| US21-P13 | Période invalide | Erreur 400 | PASS |
+| US21-P14 | Requête sans token | Accès refusé | PASS |
+
+---
+
+## Commandes de validation
+
+Backend :
+
+```bash
+./mvnw test
+```
+
+Résultat attendu :
+
+```text
+BUILD SUCCESS
+```
+
+Frontend :
+
+```bash
+npm run build
+```
+
+Résultat attendu :
+
+```text
+Application bundle generation complete
+```
+
+---
+
+## Validation Postman
+
+Endpoint CSV validé :
+
+```http
+GET /api/satellites/{satelliteId}/telemetry/report/csv?metric=temperature&metric=battery
+```
+
+Endpoint PDF validé :
+
+```http
+GET /api/satellites/{satelliteId}/telemetry/report/pdf?metric=temperature&metric=battery
+```
+
+Cas validés :
+
+- export CSV avec utilisateur autorisé ;
+- export PDF avec utilisateur autorisé ;
+- export multi-métriques ;
+- export avec période ;
+- satellite inexistant ;
+- métrique absente ;
+- période invalide ;
+- utilisateur non connecté.
+
+Résultat :
+
+```text
+PASS
+```
+
+---
+
+## Validation navigateur
+
+La génération des rapports a été validée depuis la page détail satellite.
+
+Étapes réalisées :
+
+1. ouverture d’un satellite existant ;
+2. sélection d’une ou plusieurs métriques ;
+3. sélection optionnelle d’une période ;
+4. clic sur `Exporter CSV` ;
+5. téléchargement du fichier CSV ;
+6. ouverture et vérification du CSV ;
+7. clic sur `Exporter PDF` ;
+8. téléchargement du fichier PDF ;
+9. ouverture et vérification du PDF.
+
+Résultat :
+
+```text
+PASS
+```
+
+---
+
+## Fichiers principaux modifiés
+
+| Fichier | Rôle |
+|---|---|
+| `TelemetryReportService.java` | Interface du service d’export |
+| `TelemetryReportServiceImpl.java` | Génération des rapports CSV et PDF |
+| `TelemetryReportController.java` | Endpoints d’export CSV/PDF |
+| `TelemetryReportAuthorizationIntegrationTest.java` | Tests d’intégration JUnit / MockMvc |
+| `telemetry.service.ts` | Appels HTTP vers les endpoints d’export |
+| `satellite-detail.component.ts` | Logique de téléchargement CSV/PDF |
+| `satellite-detail.component.html` | Boutons `Exporter CSV` et `Exporter PDF` |
+| `satellite-detail.component.css` | Ajustements visuels |
+| `README.md` | Documentation fonctionnelle |
+| `docs/tests/US21-tests.md` | Documentation de validation |
+
+---
+
+## Règles métier validées
+
+| Règle | Validation |
+|---|---|
+| Rapport généré à la demande | PASS |
+| Données issues de la base | PASS |
+| Aucune modification des données de télémétrie | PASS |
+| Export CSV disponible | PASS |
+| Export PDF disponible | PASS |
+| Modèle PDF standardisé | PASS |
+| Export par ADMIN | PASS |
+| Export par OPERATEUR | PASS |
+| Export par LECTEUR | PASS |
+| Refus utilisateur non connecté | PASS |
+| Filtrage par métrique | PASS |
+| Filtrage multi-métriques | PASS |
+| Filtrage par période | PASS |
+| Anomalies incluses | PASS |
+| Alertes associées prises en compte | PASS |
+| Erreur 404 si satellite inexistant | PASS |
+| Erreur 400 si métrique absente | PASS |
+| Erreur 400 si période invalide | PASS |
+
+---
+
+## Hors périmètre
+
+L’US21 ne couvre pas :
+
+- personnalisation avancée du contenu du rapport ;
+- export multi-satellites en une seule opération ;
+- génération automatique planifiée ;
+- envoi automatique du rapport par email ;
+- archivage automatique du rapport ;
+- signature numérique du PDF ;
+- génération de graphiques dans le PDF.
+
+---
+
+## Conclusion
+
+L’US21 est validée.
+
+Un utilisateur autorisé peut exporter un rapport de télémétrie en CSV ou en PDF depuis la page détail satellite.
+
+Le rapport contient les données mesurées, les métriques sélectionnées, la période optionnelle, les anomalies détectées, les alertes associées et une synthèse exploitable.

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.css
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.css
@@ -868,3 +868,25 @@ input:focus {
     flex-direction: column;
   }
 }
+
+.telemetry-report-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.telemetry-report-feedback {
+  margin-top: 16px;
+}
+
+@media (max-width: 768px) {
+  .telemetry-report-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .telemetry-report-actions button {
+    width: 100%;
+  }
+}

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.html
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.html
@@ -611,14 +611,34 @@
           </p>
         </div>
 
-        <button
-          type="button"
-          class="secondary-button"
-          (click)="refreshTelemetryChart()"
-          [disabled]="telemetryLoading || availableTelemetryMetrics.length === 0"
-        >
-          {{ telemetryLoading ? 'Chargement...' : 'Rafraîchir' }}
-        </button>
+        <div class="telemetry-report-actions">
+          <button
+            type="button"
+            class="secondary-button"
+            (click)="refreshTelemetryChart()"
+            [disabled]="telemetryLoading || availableTelemetryMetrics.length === 0"
+          >
+            {{ telemetryLoading ? 'Chargement...' : 'Rafraîchir' }}
+          </button>
+
+          <button
+            type="button"
+            class="secondary-button"
+            (click)="exportTelemetryReportCsv()"
+            [disabled]="telemetryReportCsvLoading || availableTelemetryMetrics.length === 0"
+          >
+            {{ telemetryReportCsvLoading ? 'Export CSV...' : 'Exporter CSV' }}
+          </button>
+
+          <button
+            type="button"
+            class="primary-button"
+            (click)="exportTelemetryReportPdf()"
+            [disabled]="telemetryReportPdfLoading || availableTelemetryMetrics.length === 0"
+          >
+            {{ telemetryReportPdfLoading ? 'Export PDF...' : 'Exporter PDF' }}
+          </button>
+        </div>
       </div>
 
       <div *ngIf="availableTelemetryMetrics.length === 0 && !telemetryLoading" class="info-card">
@@ -661,6 +681,14 @@
             />
           </div>
         </div>
+      </div>
+
+      <div *ngIf="telemetryReportSuccessMessage" class="success-card telemetry-report-feedback">
+        {{ telemetryReportSuccessMessage }}
+      </div>
+
+      <div *ngIf="telemetryReportErrorMessage" class="error-card telemetry-report-feedback">
+        {{ telemetryReportErrorMessage }}
       </div>
 
       <div *ngIf="telemetryErrorMessage" class="error-card">

--- a/frontend/src/app/satellites/satellite-detail/satellite-detail.component.ts
+++ b/frontend/src/app/satellites/satellite-detail/satellite-detail.component.ts
@@ -88,6 +88,11 @@ export class SatelliteDetailComponent implements OnInit {
   telemetryFrom = '';
   telemetryTo = '';
 
+  telemetryReportCsvLoading = false;
+  telemetryReportPdfLoading = false;
+  telemetryReportSuccessMessage = '';
+  telemetryReportErrorMessage = '';
+
   telemetryLoading = false;
   telemetryErrorMessage = '';
   telemetryEmptyMessage = '';
@@ -1020,4 +1025,111 @@ export class SatelliteDetailComponent implements OnInit {
 
     return new Date(timestamp).toLocaleString('fr-FR');
   }
+
+  exportTelemetryReportCsv(): void {
+    if (!this.satellite || this.selectedTelemetryMetrics.length === 0) {
+      this.telemetryReportErrorMessage = 'Sélectionne au moins une métrique à exporter.';
+      this.telemetryReportSuccessMessage = '';
+      return;
+    }
+
+    const fromIso = this.toIsoDateOrNull(this.telemetryFrom);
+    const toIso = this.toIsoDateOrNull(this.telemetryTo);
+
+    this.telemetryReportCsvLoading = true;
+    this.telemetryReportErrorMessage = '';
+    this.telemetryReportSuccessMessage = '';
+
+    const filename = `telemetry-report-${this.satellite.id}.csv`;
+
+    this.telemetryService
+      .exportTelemetryReportCsv(
+        this.satellite.id,
+        this.selectedTelemetryMetrics,
+        fromIso,
+        toIso
+      )
+      .subscribe({
+        next: (blob) => {
+          this.telemetryReportCsvLoading = false;
+          this.downloadBlob(blob, filename);
+          this.telemetryReportSuccessMessage = 'Rapport de télémétrie CSV généré avec succès.';
+        },
+        error: (error) => {
+          this.telemetryReportCsvLoading = false;
+          this.handleTelemetryReportError(error);
+        }
+      });
+  }
+
+  exportTelemetryReportPdf(): void {
+    if (!this.satellite || this.selectedTelemetryMetrics.length === 0) {
+      this.telemetryReportErrorMessage = 'Sélectionne au moins une métrique à exporter.';
+      this.telemetryReportSuccessMessage = '';
+      return;
+    }
+
+    const fromIso = this.toIsoDateOrNull(this.telemetryFrom);
+    const toIso = this.toIsoDateOrNull(this.telemetryTo);
+
+    this.telemetryReportPdfLoading = true;
+    this.telemetryReportErrorMessage = '';
+    this.telemetryReportSuccessMessage = '';
+
+    const filename = `telemetry-report-${this.satellite.id}.pdf`;
+
+    this.telemetryService
+      .exportTelemetryReportPdf(
+        this.satellite.id,
+        this.selectedTelemetryMetrics,
+        fromIso,
+        toIso
+      )
+      .subscribe({
+        next: (blob) => {
+          this.telemetryReportPdfLoading = false;
+          this.downloadBlob(blob, filename);
+          this.telemetryReportSuccessMessage = 'Rapport de télémétrie PDF généré avec succès.';
+        },
+        error: (error) => {
+          this.telemetryReportPdfLoading = false;
+          this.handleTelemetryReportError(error);
+        }
+      });
+  }
+
+  private handleTelemetryReportError(error: any): void {
+    if (error.status === 403) {
+      this.router.navigate(['/forbidden']);
+      return;
+    }
+
+    if (error.status === 404) {
+      this.telemetryReportErrorMessage = 'Satellite introuvable.';
+      return;
+    }
+
+    if (error.status === 400) {
+      this.telemetryReportErrorMessage = 'Filtres invalides pour le rapport de télémétrie.';
+      return;
+    }
+
+    this.telemetryReportErrorMessage = 'Impossible de générer le rapport de télémétrie.';
+  }
+
+  private downloadBlob(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+
+    link.href = url;
+    link.download = filename;
+    link.style.display = 'none';
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    window.URL.revokeObjectURL(url);
+  }
+
 }

--- a/frontend/src/app/telemetry/services/telemetry.service.ts
+++ b/frontend/src/app/telemetry/services/telemetry.service.ts
@@ -118,4 +118,62 @@ export class TelemetryService {
       { params }
     );
   }
+
+  exportTelemetryReportCsv(
+    satelliteId: number,
+    metrics: string[],
+    from?: string | null,
+    to?: string | null
+  ): Observable<Blob> {
+    let params = new HttpParams();
+
+    metrics.forEach((metric) => {
+      params = params.append('metric', metric);
+    });
+
+    if (from) {
+      params = params.set('from', from);
+    }
+
+    if (to) {
+      params = params.set('to', to);
+    }
+
+    return this.http.get(
+      `${this.apiUrl}/satellites/${satelliteId}/telemetry/report/csv`,
+      {
+        params,
+        responseType: 'blob'
+      }
+    );
+  }
+
+  exportTelemetryReportPdf(
+    satelliteId: number,
+    metrics: string[],
+    from?: string | null,
+    to?: string | null
+  ): Observable<Blob> {
+    let params = new HttpParams();
+
+    metrics.forEach((metric) => {
+      params = params.append('metric', metric);
+    });
+
+    if (from) {
+      params = params.set('from', from);
+    }
+
+    if (to) {
+      params = params.set('to', to);
+    }
+
+    return this.http.get(
+      `${this.apiUrl}/satellites/${satelliteId}/telemetry/report/pdf`,
+      {
+        params,
+        responseType: 'blob'
+      }
+    );
+  }
 }


### PR DESCRIPTION
## Résumé

Cette PR ajoute l’US21 : export d’un rapport de télémétrie en CSV et PDF.

Elle permet à un utilisateur autorisé d’exporter les données de télémétrie d’un satellite afin de pouvoir les analyser, les partager ou les archiver.

Le rapport est généré à la demande, à partir des données existantes en base, et ne modifie pas les données de télémétrie.

---

## Changements principaux

- Ajout du service `TelemetryReportService`
- Ajout de l’implémentation `TelemetryReportServiceImpl`
- Ajout du contrôleur `TelemetryReportController`
- Ajout des endpoints d’export :
  - `GET /api/satellites/{satelliteId}/telemetry/report/csv`
  - `GET /api/satellites/{satelliteId}/telemetry/report/pdf`
- Export CSV des points de télémétrie
- Export PDF standardisé avec synthèse télémétrie
- Support du filtrage par métrique
- Support du filtrage multi-métriques
- Support du filtrage optionnel par période `from` / `to`
- Inclusion des anomalies associées aux points de télémétrie
- Prise en compte des alertes associées
- Ajout d’une limite de volumétrie à 10 000 points
- Ajout des boutons frontend `Exporter CSV` et `Exporter PDF`
- Téléchargement navigateur des fichiers générés
- Gestion des erreurs frontend `400`, `403`, `404`
- Ajout des tests d’intégration JUnit / Spring Boot / MockMvc
- Mise à jour du `README.md`
- Ajout de `docs/tests/US21-tests.md`

---

## Endpoints ajoutés

| Méthode | Endpoint | Format | Rôles autorisés |
|---|---|---|---|
| `GET` | `/api/satellites/{satelliteId}/telemetry/report/csv` | CSV | ADMIN, OPERATEUR, LECTEUR |
| `GET` | `/api/satellites/{satelliteId}/telemetry/report/pdf` | PDF | ADMIN, OPERATEUR, LECTEUR |

---

## Paramètres disponibles

| Paramètre | Obligatoire | Description |
|---|---|---|
| `metric` | Oui | Métrique à exporter |
| `metric` répété | Non | Permet d’exporter plusieurs métriques |
| `from` | Non | Date de début de période |
| `to` | Non | Date de fin de période |

Exemple :

```http
GET /api/satellites/3/telemetry/report/csv?metric=temperature&metric=battery
```

Exemple avec période :

```http
GET /api/satellites/3/telemetry/report/pdf?metric=temperature&from=2026-01-01T10:00:00Z&to=2026-01-01T11:00:00Z
```

---

## Contenu du rapport CSV

Le fichier CSV contient les colonnes suivantes :

```text
missionId;missionName;satelliteId;satelliteName;timestamp;metric;value;anomalyFlag;anomalyType;anomalySeverity;anomalyMessage
```

Le CSV inclut :

- la mission associée ;
- le satellite associé ;
- les timestamps ;
- les métriques ;
- les valeurs mesurées ;
- l’indicateur d’anomalie ;
- le type d’anomalie ;
- la gravité de l’anomalie ;
- le message associé à l’anomalie.

Le fichier utilise :

- encodage UTF-8 avec BOM ;
- séparateur `;` ;
- fins de ligne CRLF.

---

## Contenu du rapport PDF

Le rapport PDF contient :

- métadonnées du rapport ;
- date de génération ;
- utilisateur ayant généré le rapport ;
- informations générales mission / satellite ;
- période couverte ;
- métriques analysées ;
- nombre de points exportés ;
- statistiques par métrique : minimum, maximum, moyenne ;
- synthèse des anomalies ;
- dernières anomalies ;
- synthèse des alertes associées ;
- derniers points de télémétrie ;
- conclusion automatique.

---

## Frontend

La page détail satellite propose désormais deux boutons dans la section télémétrie :

```text
Exporter CSV
Exporter PDF
```

L’utilisateur peut :

- sélectionner une ou plusieurs métriques ;
- définir une période optionnelle ;
- exporter les données en CSV ;
- exporter un rapport synthétique en PDF.

Les erreurs sont gérées côté interface :

- `400` : filtres invalides ;
- `403` : redirection vers forbidden ;
- `404` : satellite introuvable ;
- autre erreur : message d’échec de génération.

---

## Sécurité

Les rôles autorisés à exporter un rapport de télémétrie sont :

- ADMIN
- OPERATEUR
- LECTEUR

Un utilisateur non connecté est refusé.

---

## Tests réalisés

### Backend

Les tests d’intégration JUnit / Spring Boot / MockMvc couvrent :

- export CSV avec rôle ADMIN ;
- export CSV avec rôle LECTEUR ;
- export PDF avec rôle ADMIN ;
- export PDF avec rôle LECTEUR ;
- export multi-métriques ;
- filtrage par métrique ;
- filtrage par période ;
- satellite inexistant retournant `404` ;
- métrique absente retournant `400` ;
- période invalide retournant `400` ;
- utilisateur non connecté refusé ;
- vérification du `Content-Type` CSV ;
- vérification du `Content-Type` PDF ;
- vérification du `Content-Disposition` ;
- vérification que le CSV est non vide ;
- vérification que le PDF est non vide ;
- vérification que le PDF commence par `%PDF` ;
- vérification que les anomalies sont incluses dans l’export.

Commande exécutée :

```bash
./mvnw test
```

Résultat :

```text
BUILD SUCCESS
```

---

### Frontend

Commande exécutée :

```bash
npm run build
```

Résultat :

```text
Build OK
```

Validations réalisées :

- affichage des boutons `Exporter CSV` et `Exporter PDF` ;
- export CSV depuis le navigateur ;
- export PDF depuis le navigateur ;
- téléchargement des fichiers ;
- ouverture correcte du CSV ;
- ouverture correcte du PDF ;
- sélection multi-métriques ;
- filtrage par période ;
- gestion des messages d’erreur.

---

### Postman

Tests Postman réalisés :

- export CSV `200 OK` ;
- export PDF `200 OK` ;
- vérification des headers CSV ;
- vérification des headers PDF ;
- vérification des colonnes CSV ;
- vérification réponse non vide ;
- satellite inexistant `404` ;
- métrique absente `400` ;
- période invalide `400` ;
- utilisateur non connecté refusé.

---

## Règles métier validées

- Le rapport est généré à la demande.
- Les données exportées correspondent aux données existantes en base.
- L’export ne modifie pas les données de télémétrie.
- Le format PDF est standardisé.
- Le rapport concerne un seul satellite.
- Plusieurs métriques peuvent être exportées en une demande.
- La période `from` / `to` est optionnelle.
- Les anomalies associées sont incluses.
- Les alertes associées sont prises en compte.
- Les rôles ADMIN, OPERATEUR et LECTEUR peuvent exporter.
- Un utilisateur non connecté est refusé.

---

## Hors périmètre

Cette PR ne couvre pas :

- personnalisation avancée du rapport ;
- export multi-satellites en une seule opération ;
- génération automatique planifiée ;
- envoi automatique par email ;
- archivage automatique du rapport ;
- signature numérique du PDF ;
- génération de graphiques dans le PDF.

---

## Conclusion

L’US21 est terminée.

Un utilisateur autorisé peut exporter un rapport de télémétrie en CSV ou en PDF depuis la page détail satellite.

Le rapport prend en compte les métriques sélectionnées, la période optionnelle, les anomalies détectées, les alertes associées et fournit une synthèse exploitable des données mesurées.