### PR TITLE
feat: add admin user management

### DIFF
--- a/backend/src/main/java/com/finalspace/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/finalspace/backend/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.finalspace.backend.telemetry.TelemetryImportException;
 import com.finalspace.backend.telemetry.dto.TelemetryImportResponse;
 
+import com.finalspace.backend.user.UserEmailAlreadyExistsException;
+import com.finalspace.backend.user.UserNotFoundException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -56,5 +59,23 @@ public class GlobalExceptionHandler {
                         exception.getErrors()
                 )
         );
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<String> handleUserNotFound(
+            UserNotFoundException exception
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(exception.getMessage());
+    }
+
+    @ExceptionHandler(UserEmailAlreadyExistsException.class)
+    public ResponseEntity<String> handleUserEmailAlreadyExists(
+            UserEmailAlreadyExistsException exception
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(exception.getMessage());
     }
 }

--- a/backend/src/main/java/com/finalspace/backend/user/UserEmailAlreadyExistsException.java
+++ b/backend/src/main/java/com/finalspace/backend/user/UserEmailAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.finalspace.backend.user;
+
+public class UserEmailAlreadyExistsException extends RuntimeException {
+
+    public UserEmailAlreadyExistsException(String email) {
+        super("Un utilisateur existe déjà avec l'email : " + email);
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/user/UserNotFoundException.java
+++ b/backend/src/main/java/com/finalspace/backend/user/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package com.finalspace.backend.user;
+
+public class UserNotFoundException extends RuntimeException {
+
+    public UserNotFoundException(Long id) {
+        super("Utilisateur introuvable avec l'identifiant : " + id);
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/finalspace/backend/user/controller/UserController.java
@@ -1,0 +1,53 @@
+package com.finalspace.backend.user.controller;
+
+import com.finalspace.backend.user.dto.UserCreateRequest;
+import com.finalspace.backend.user.dto.UserResponse;
+import com.finalspace.backend.user.dto.UserStatusRequest;
+import com.finalspace.backend.user.dto.UserUpdateRequest;
+import com.finalspace.backend.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public List<UserResponse> findAll() {
+        return userService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public UserResponse findById(@PathVariable Long id) {
+        return userService.findById(id);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserResponse create(@Valid @RequestBody UserCreateRequest request) {
+        return userService.create(request);
+    }
+
+    @PutMapping("/{id}")
+    public UserResponse update(
+            @PathVariable Long id,
+            @Valid @RequestBody UserUpdateRequest request
+    ) {
+        return userService.update(id, request);
+    }
+
+    @PatchMapping("/{id}/status")
+    public UserResponse updateStatus(
+            @PathVariable Long id,
+            @Valid @RequestBody UserStatusRequest request
+    ) {
+        return userService.updateStatus(id, request);
+    }
+}

--- a/backend/src/main/java/com/finalspace/backend/user/dto/UserCreateRequest.java
+++ b/backend/src/main/java/com/finalspace/backend/user/dto/UserCreateRequest.java
@@ -1,0 +1,22 @@
+package com.finalspace.backend.user.dto;
+
+import com.finalspace.backend.user.RoleType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UserCreateRequest(
+
+        @NotBlank(message = "L'email est obligatoire")
+        @Email(message = "L'email doit être valide")
+        String email,
+
+        @NotBlank(message = "Le mot de passe est obligatoire")
+        @Size(min = 8, message = "Le mot de passe doit contenir au moins 8 caractères")
+        String password,
+
+        @NotNull(message = "Le rôle est obligatoire")
+        RoleType role
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/user/dto/UserResponse.java
+++ b/backend/src/main/java/com/finalspace/backend/user/dto/UserResponse.java
@@ -1,0 +1,14 @@
+package com.finalspace.backend.user.dto;
+
+import com.finalspace.backend.user.RoleType;
+
+import java.time.LocalDateTime;
+
+public record UserResponse(
+        Long id,
+        String email,
+        RoleType role,
+        boolean active,
+        LocalDateTime createdAt
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/user/dto/UserStatusRequest.java
+++ b/backend/src/main/java/com/finalspace/backend/user/dto/UserStatusRequest.java
@@ -1,0 +1,10 @@
+package com.finalspace.backend.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserStatusRequest(
+
+        @NotNull(message = "Le statut actif est obligatoire")
+        Boolean active
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/user/dto/UserUpdateRequest.java
+++ b/backend/src/main/java/com/finalspace/backend/user/dto/UserUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.finalspace.backend.user.dto;
+
+import com.finalspace.backend.user.RoleType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserUpdateRequest(
+
+        @NotBlank(message = "L'email est obligatoire")
+        @Email(message = "L'email doit être valide")
+        String email,
+
+        @NotNull(message = "Le rôle est obligatoire")
+        RoleType role
+) {
+}

--- a/backend/src/main/java/com/finalspace/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/finalspace/backend/user/service/UserService.java
@@ -1,0 +1,96 @@
+package com.finalspace.backend.user.service;
+
+import com.finalspace.backend.user.User;
+import com.finalspace.backend.user.UserEmailAlreadyExistsException;
+import com.finalspace.backend.user.UserNotFoundException;
+import com.finalspace.backend.user.UserRepository;
+import com.finalspace.backend.user.dto.UserCreateRequest;
+import com.finalspace.backend.user.dto.UserResponse;
+import com.finalspace.backend.user.dto.UserStatusRequest;
+import com.finalspace.backend.user.dto.UserUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public List<UserResponse> findAll() {
+        return userRepository.findAll()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public UserResponse findById(Long id) {
+        return toResponse(getUser(id));
+    }
+
+    @Transactional
+    public UserResponse create(UserCreateRequest request) {
+        String normalizedEmail = request.email().trim().toLowerCase();
+
+        if (userRepository.findByEmail(normalizedEmail).isPresent()) {
+            throw new UserEmailAlreadyExistsException(normalizedEmail);
+        }
+
+        User user = User.builder()
+                .email(normalizedEmail)
+                .passwordHash(passwordEncoder.encode(request.password()))
+                .role(request.role())
+                .isActive(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return toResponse(userRepository.save(user));
+    }
+
+    @Transactional
+    public UserResponse update(Long id, UserUpdateRequest request) {
+        User user = getUser(id);
+        String normalizedEmail = request.email().trim().toLowerCase();
+
+        userRepository.findByEmail(normalizedEmail)
+                .filter(existingUser -> !existingUser.getId().equals(id))
+                .ifPresent(existingUser -> {
+                    throw new UserEmailAlreadyExistsException(normalizedEmail);
+                });
+
+        user.setEmail(normalizedEmail);
+        user.setRole(request.role());
+
+        return toResponse(userRepository.save(user));
+    }
+
+    @Transactional
+    public UserResponse updateStatus(Long id, UserStatusRequest request) {
+        User user = getUser(id);
+        user.setActive(request.active());
+
+        return toResponse(userRepository.save(user));
+    }
+
+    private User getUser(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException(id));
+    }
+
+    private UserResponse toResponse(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getRole(),
+                user.isActive(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/frontend/src/app/admin/users/models/user.model.ts
+++ b/frontend/src/app/admin/users/models/user.model.ts
@@ -1,0 +1,24 @@
+export type UserRole = 'ADMIN' | 'OPERATEUR' | 'LECTEUR';
+
+export interface User {
+  id: number;
+  email: string;
+  role: UserRole;
+  active: boolean;
+  createdAt: string;
+}
+
+export interface UserCreateRequest {
+  email: string;
+  password: string;
+  role: UserRole;
+}
+
+export interface UserUpdateRequest {
+  email: string;
+  role: UserRole;
+}
+
+export interface UserStatusRequest {
+  active: boolean;
+}

--- a/frontend/src/app/admin/users/services/user.service.ts
+++ b/frontend/src/app/admin/users/services/user.service.ts
@@ -1,0 +1,44 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import {
+  User,
+  UserCreateRequest,
+  UserStatusRequest,
+  UserUpdateRequest
+} from '../models/user.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserService {
+
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = '/api/users';
+
+  getUsers(): Observable<User[]> {
+    return this.http.get<User[]>(this.apiUrl);
+  }
+
+  getUser(id: number): Observable<User> {
+    return this.http.get<User>(`${this.apiUrl}/${id}`);
+  }
+
+  createUser(request: UserCreateRequest): Observable<User> {
+    return this.http.post<User>(this.apiUrl, request);
+  }
+
+  updateUser(id: number, request: UserUpdateRequest): Observable<User> {
+    return this.http.put<User>(`${this.apiUrl}/${id}`, request);
+  }
+
+  updateStatus(id: number, active: boolean): Observable<User> {
+    const request: UserStatusRequest = { active };
+
+    return this.http.patch<User>(
+      `${this.apiUrl}/${id}/status`,
+      request
+    );
+  }
+}

--- a/frontend/src/app/admin/users/user-form-page/user-form-page.component.css
+++ b/frontend/src/app/admin/users/user-form-page/user-form-page.component.css
@@ -1,0 +1,329 @@
+:host {
+  display: block;
+}
+
+.user-form-page {
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.page-header {
+  margin-bottom: 24px;
+
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.page-eyebrow {
+  margin: 0 0 8px;
+
+  color: #f59e0b;
+
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  margin: 0;
+
+  color: #f8fafc;
+  font-size: clamp(28px, 4vw, 40px);
+}
+
+.page-description {
+  max-width: 700px;
+  margin: 10px 0 0;
+
+  color: #94a3b8;
+  line-height: 1.6;
+}
+
+.back-link,
+.cancel-button,
+.submit-button {
+  border-radius: 10px;
+
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.back-link,
+.cancel-button {
+  padding: 10px 14px;
+
+  border: 1px solid #334155;
+
+  background: #111827;
+  color: #e2e8f0;
+}
+
+.back-link:hover,
+.cancel-button:hover {
+  background: #1e293b;
+}
+
+.message-card,
+.state-card,
+.user-form-card {
+  border: 1px solid #253047;
+  background: #0f172a;
+}
+
+.message-card {
+  margin-bottom: 18px;
+  padding: 14px 16px;
+
+  border-radius: 12px;
+}
+
+.success-message {
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #86efac;
+}
+
+.error-message {
+  border-color: rgba(239, 68, 68, 0.5);
+  color: #fca5a5;
+}
+
+.state-card {
+  padding: 32px;
+
+  border-radius: 14px;
+
+  color: #94a3b8;
+  text-align: center;
+}
+
+.user-form-card {
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.form-section {
+  padding: 28px;
+
+  border-bottom: 1px solid #253047;
+}
+
+.section-heading {
+  margin-bottom: 24px;
+
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.section-number {
+  width: 40px;
+  height: 40px;
+
+  display: grid;
+  place-items: center;
+  flex: 0 0 40px;
+
+  border-radius: 12px;
+
+  background: rgba(245, 158, 11, 0.14);
+  color: #f59e0b;
+
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.section-heading h2 {
+  margin: 0;
+
+  color: #f8fafc;
+  font-size: 20px;
+}
+
+.section-heading p {
+  margin: 7px 0 0;
+
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-field label {
+  color: #cbd5e1;
+
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.form-field input {
+  min-height: 46px;
+  padding: 0 14px;
+
+  border: 1px solid #334155;
+  border-radius: 10px;
+
+  background: #07101f;
+  color: #f8fafc;
+
+  outline: none;
+}
+
+.form-field input:focus {
+  border-color: #f59e0b;
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.12);
+}
+
+.form-field input.ng-invalid.ng-touched {
+  border-color: #ef4444;
+}
+
+.field-help {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.field-error {
+  color: #fca5a5;
+  font-size: 12px;
+}
+
+.role-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.role-card {
+  min-height: 170px;
+  padding: 18px;
+
+  display: flex;
+  flex-direction: column;
+
+  border: 1px solid #334155;
+  border-radius: 14px;
+
+  background: #07101f;
+
+  cursor: pointer;
+
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    transform 150ms ease;
+}
+
+.role-card:hover {
+  transform: translateY(-2px);
+  border-color: #64748b;
+}
+
+.role-card.selected {
+  border-color: #f59e0b;
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.role-card input {
+  width: 16px;
+  height: 16px;
+
+  accent-color: #f59e0b;
+}
+
+.role-title {
+  margin-top: 18px;
+
+  color: #f8fafc;
+  font-size: 17px;
+  font-weight: 800;
+}
+
+.role-description {
+  margin-top: 10px;
+
+  color: #94a3b8;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.form-actions {
+  padding: 22px 28px;
+
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+
+  background: #111827;
+}
+
+.submit-button {
+  padding: 11px 18px;
+
+  border: 1px solid #f59e0b;
+
+  background: #f59e0b;
+  color: #111827;
+
+  cursor: pointer;
+}
+
+.submit-button:hover {
+  background: #fbbf24;
+}
+
+.submit-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 850px) {
+  .role-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 700px) {
+  .page-header {
+    flex-direction: column;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-section {
+    padding: 22px 18px;
+  }
+
+  .form-actions {
+    padding: 18px;
+
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .cancel-button,
+  .submit-button {
+    text-align: center;
+  }
+}

--- a/frontend/src/app/admin/users/user-form-page/user-form-page.component.html
+++ b/frontend/src/app/admin/users/user-form-page/user-form-page.component.html
@@ -1,0 +1,261 @@
+<p>user-form-page works!</p>
+<section class="user-form-page">
+
+  <header class="page-header">
+
+    <div>
+      <p class="page-eyebrow">
+        Administration
+      </p>
+
+      <h1>
+        {{ pageTitle }}
+      </h1>
+
+      <p class="page-description">
+        {{
+          isEditMode
+            ? 'Modifiez l’adresse email ou le rôle du compte.'
+            : 'Créez un nouveau compte utilisateur pour Final Space.'
+        }}
+      </p>
+    </div>
+
+    <a
+      routerLink="/admin/users"
+      class="back-link"
+    >
+      Retour à la liste
+    </a>
+
+  </header>
+
+  <div
+    *ngIf="successMessage"
+    class="message-card success-message"
+    role="status"
+  >
+    {{ successMessage }}
+  </div>
+
+  <div
+    *ngIf="errorMessage"
+    class="message-card error-message"
+    role="alert"
+  >
+    {{ errorMessage }}
+  </div>
+
+  <div
+    *ngIf="loading"
+    class="state-card"
+  >
+    Chargement de l’utilisateur...
+  </div>
+
+  <form
+    *ngIf="!loading"
+    class="user-form-card"
+    [formGroup]="form"
+    (ngSubmit)="submit()"
+  >
+
+    <section class="form-section">
+
+      <div class="section-heading">
+        <span class="section-number">
+          01
+        </span>
+
+        <div>
+          <h2>
+            Informations du compte
+          </h2>
+
+          <p>
+            Renseignez les informations principales de l’utilisateur.
+          </p>
+        </div>
+      </div>
+
+      <div class="form-grid">
+
+        <div class="form-field full-width">
+
+          <label for="user-email">
+            Adresse email
+          </label>
+
+          <input
+            id="user-email"
+            type="email"
+            formControlName="email"
+            autocomplete="email"
+            placeholder="utilisateur@finalspace.com"
+          >
+
+          <small
+            *ngIf="
+              emailControl.touched &&
+              emailControl.hasError('required')
+            "
+            class="field-error"
+          >
+            L’adresse email est obligatoire.
+          </small>
+
+          <small
+            *ngIf="
+              emailControl.touched &&
+              emailControl.hasError('email')
+            "
+            class="field-error"
+          >
+            L’adresse email doit être valide.
+          </small>
+
+          <small
+            *ngIf="
+              emailControl.touched &&
+              emailControl.hasError('maxlength')
+            "
+            class="field-error"
+          >
+            L’adresse email est trop longue.
+          </small>
+
+        </div>
+
+        <div
+          *ngIf="!isEditMode"
+          class="form-field full-width"
+        >
+
+          <label for="user-password">
+            Mot de passe
+          </label>
+
+          <input
+            id="user-password"
+            type="password"
+            formControlName="password"
+            autocomplete="new-password"
+            placeholder="8 caractères minimum"
+          >
+
+          <small class="field-help">
+            Le mot de passe doit contenir au moins 8 caractères.
+          </small>
+
+          <small
+            *ngIf="
+              passwordControl.touched &&
+              passwordControl.hasError('required')
+            "
+            class="field-error"
+          >
+            Le mot de passe est obligatoire.
+          </small>
+
+          <small
+            *ngIf="
+              passwordControl.touched &&
+              passwordControl.hasError('minlength')
+            "
+            class="field-error"
+          >
+            Le mot de passe doit contenir au moins 8 caractères.
+          </small>
+
+        </div>
+
+      </div>
+
+    </section>
+
+    <section class="form-section">
+
+      <div class="section-heading">
+        <span class="section-number">
+          02
+        </span>
+
+        <div>
+          <h2>
+            Rôle et autorisations
+          </h2>
+
+          <p>
+            Définissez le niveau d’accès de l’utilisateur.
+          </p>
+        </div>
+      </div>
+
+      <div class="role-grid">
+
+        <label
+          *ngFor="let role of roles"
+          class="role-card"
+          [class.selected]="roleControl.value === role"
+        >
+
+          <input
+            type="radio"
+            formControlName="role"
+            [value]="role"
+          >
+
+          <span class="role-title">
+            {{ getRoleLabel(role) }}
+          </span>
+
+          <span class="role-description">
+
+            <ng-container [ngSwitch]="role">
+
+              <span *ngSwitchCase="'ADMIN'">
+                Accès complet, administration des utilisateurs et gestion
+                opérationnelle.
+              </span>
+
+              <span *ngSwitchCase="'OPERATEUR'">
+                Création et gestion des missions, satellites, simulations,
+                alertes et incidents.
+              </span>
+
+              <span *ngSwitchCase="'LECTEUR'">
+                Consultation en lecture seule des données et rapports.
+              </span>
+
+            </ng-container>
+
+          </span>
+
+        </label>
+
+      </div>
+
+    </section>
+
+    <footer class="form-actions">
+
+      <a
+        routerLink="/admin/users"
+        class="cancel-button"
+      >
+        Annuler
+      </a>
+
+      <button
+        type="submit"
+        class="submit-button"
+        [disabled]="saving"
+      >
+        {{ submitLabel }}
+      </button>
+
+    </footer>
+
+  </form>
+
+</section>

--- a/frontend/src/app/admin/users/user-form-page/user-form-page.component.spec.ts
+++ b/frontend/src/app/admin/users/user-form-page/user-form-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserFormPageComponent } from './user-form-page.component';
+
+describe('UserFormPageComponent', () => {
+  let component: UserFormPageComponent;
+  let fixture: ComponentFixture<UserFormPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserFormPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(UserFormPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/admin/users/user-form-page/user-form-page.component.ts
+++ b/frontend/src/app/admin/users/user-form-page/user-form-page.component.ts
@@ -1,0 +1,304 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+
+import {
+  UserCreateRequest,
+  UserRole,
+  UserUpdateRequest
+} from '../models/user.model';
+import { UserService } from '../services/user.service';
+
+@Component({
+  selector: 'app-user-form-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterLink
+  ],
+  templateUrl: './user-form-page.component.html',
+  styleUrl: './user-form-page.component.css'
+})
+export class UserFormPageComponent implements OnInit {
+
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly userService = inject(UserService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  readonly roles: UserRole[] = [
+    'ADMIN',
+    'OPERATEUR',
+    'LECTEUR'
+  ];
+
+  readonly form = this.formBuilder.nonNullable.group({
+    email: [
+      '',
+      [
+        Validators.required,
+        Validators.email,
+        Validators.maxLength(255)
+      ]
+    ],
+    password: [
+      '',
+      [
+        Validators.minLength(8),
+        Validators.maxLength(100)
+      ]
+    ],
+    role: [
+      'LECTEUR' as UserRole,
+      Validators.required
+    ]
+  });
+
+  userId: number | null = null;
+
+  loading = false;
+  saving = false;
+
+  errorMessage = '';
+  successMessage = '';
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+
+    if (!idParam) {
+      this.configureCreateMode();
+      return;
+    }
+
+    const parsedId = Number(idParam);
+
+    if (!Number.isInteger(parsedId) || parsedId <= 0) {
+      this.router.navigate(['/admin/users']);
+      return;
+    }
+
+    this.userId = parsedId;
+    this.configureEditMode();
+    this.loadUser(parsedId);
+  }
+
+  get isEditMode(): boolean {
+    return this.userId !== null;
+  }
+
+  get pageTitle(): string {
+    return this.isEditMode
+      ? 'Modifier un utilisateur'
+      : 'Créer un utilisateur';
+  }
+
+  get submitLabel(): string {
+    if (this.saving) {
+      return 'Enregistrement...';
+    }
+
+    return this.isEditMode
+      ? 'Enregistrer les modifications'
+      : 'Créer l’utilisateur';
+  }
+
+  get emailControl() {
+    return this.form.controls.email;
+  }
+
+  get passwordControl() {
+    return this.form.controls.password;
+  }
+
+  get roleControl() {
+    return this.form.controls.role;
+  }
+
+  submit(): void {
+    this.errorMessage = '';
+    this.successMessage = '';
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      this.errorMessage =
+        'Veuillez corriger les champs invalides avant de continuer.';
+      return;
+    }
+
+    if (!this.isEditMode && !this.form.controls.password.value.trim()) {
+      this.form.controls.password.setErrors({
+        required: true
+      });
+      this.form.controls.password.markAsTouched();
+
+      this.errorMessage =
+        'Le mot de passe est obligatoire pour créer un utilisateur.';
+      return;
+    }
+
+    this.saving = true;
+
+    if (this.isEditMode && this.userId !== null) {
+      this.updateUser(this.userId);
+      return;
+    }
+
+    this.createUser();
+  }
+
+  getRoleLabel(role: UserRole): string {
+    switch (role) {
+      case 'ADMIN':
+        return 'Administrateur';
+      case 'OPERATEUR':
+        return 'Opérateur';
+      case 'LECTEUR':
+        return 'Lecteur';
+    }
+  }
+
+  private configureCreateMode(): void {
+    this.form.controls.password.addValidators(
+      Validators.required
+    );
+    this.form.controls.password.updateValueAndValidity();
+  }
+
+  private configureEditMode(): void {
+    this.form.controls.password.disable();
+    this.form.controls.password.clearValidators();
+    this.form.controls.password.updateValueAndValidity();
+  }
+
+  private loadUser(id: number): void {
+    this.loading = true;
+    this.errorMessage = '';
+
+    this.userService.getUser(id).subscribe({
+      next: (user) => {
+        this.form.patchValue({
+          email: user.email,
+          role: user.role
+        });
+
+        this.loading = false;
+      },
+      error: (error) => {
+        this.errorMessage = this.extractErrorMessage(
+          error,
+          'Impossible de charger l’utilisateur.'
+        );
+
+        this.loading = false;
+      }
+    });
+  }
+
+  private createUser(): void {
+    const rawValue = this.form.getRawValue();
+
+    const request: UserCreateRequest = {
+      email: rawValue.email.trim().toLowerCase(),
+      password: rawValue.password,
+      role: rawValue.role
+    };
+
+    this.userService.createUser(request).subscribe({
+      next: () => {
+        this.successMessage =
+          'L’utilisateur a été créé avec succès.';
+
+        this.saving = false;
+
+        setTimeout(() => {
+          this.router.navigate(['/admin/users']);
+        }, 700);
+      },
+      error: (error) => {
+        this.errorMessage = this.extractErrorMessage(
+          error,
+          'Impossible de créer l’utilisateur.'
+        );
+
+        this.saving = false;
+      }
+    });
+  }
+
+  private updateUser(id: number): void {
+    const rawValue = this.form.getRawValue();
+
+    const request: UserUpdateRequest = {
+      email: rawValue.email.trim().toLowerCase(),
+      role: rawValue.role
+    };
+
+    this.userService.updateUser(id, request).subscribe({
+      next: () => {
+        this.successMessage =
+          'L’utilisateur a été modifié avec succès.';
+
+        this.saving = false;
+
+        setTimeout(() => {
+          this.router.navigate(['/admin/users']);
+        }, 700);
+      },
+      error: (error) => {
+        this.errorMessage = this.extractErrorMessage(
+          error,
+          'Impossible de modifier l’utilisateur.'
+        );
+
+        this.saving = false;
+      }
+    });
+  }
+
+  private extractErrorMessage(
+    error: unknown,
+    fallbackMessage: string
+  ): string {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'error' in error
+    ) {
+      const responseBody = (
+        error as {
+          error?: unknown;
+        }
+      ).error;
+
+      if (
+        typeof responseBody === 'string' &&
+        responseBody.trim()
+      ) {
+        return responseBody;
+      }
+
+      if (
+        typeof responseBody === 'object' &&
+        responseBody !== null &&
+        'message' in responseBody
+      ) {
+        const message = (
+          responseBody as {
+            message?: unknown;
+          }
+        ).message;
+
+        if (
+          typeof message === 'string' &&
+          message.trim()
+        ) {
+          return message;
+        }
+      }
+    }
+
+    return fallbackMessage;
+  }
+}

--- a/frontend/src/app/admin/users/user-list-page/user-list-page.component.css
+++ b/frontend/src/app/admin/users/user-list-page/user-list-page.component.css
@@ -1,0 +1,418 @@
+:host {
+  display: block;
+}
+
+.users-page {
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+.page-header {
+  margin-bottom: 24px;
+
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.page-eyebrow {
+  margin: 0 0 8px;
+
+  color: #f59e0b;
+
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  margin: 0;
+
+  color: #f8fafc;
+  font-size: clamp(28px, 4vw, 40px);
+}
+
+.page-description {
+  max-width: 720px;
+  margin: 10px 0 0;
+
+  color: #94a3b8;
+  line-height: 1.6;
+}
+
+.page-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.primary-button,
+.secondary-button,
+.reset-button,
+.edit-link,
+.status-button {
+  border-radius: 10px;
+
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+
+  cursor: pointer;
+}
+
+.primary-button {
+  padding: 11px 16px;
+
+  border: 1px solid #f59e0b;
+
+  background: #f59e0b;
+  color: #111827;
+}
+
+.primary-button:hover {
+  background: #fbbf24;
+}
+
+.secondary-button,
+.reset-button {
+  padding: 10px 14px;
+
+  border: 1px solid #334155;
+
+  background: #111827;
+  color: #e2e8f0;
+}
+
+.secondary-button:hover,
+.reset-button:hover {
+  background: #1e293b;
+}
+
+.secondary-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.message-card,
+.filters-card,
+.summary-card,
+.state-card,
+.table-wrapper {
+  border: 1px solid #253047;
+  background: #0f172a;
+}
+
+.message-card {
+  margin-bottom: 18px;
+  padding: 14px 16px;
+
+  border-radius: 12px;
+}
+
+.success-message {
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #86efac;
+}
+
+.error-message {
+  border-color: rgba(239, 68, 68, 0.5);
+  color: #fca5a5;
+}
+
+.filters-card {
+  margin-bottom: 18px;
+  padding: 18px;
+
+  display: grid;
+  grid-template-columns:
+    minmax(220px, 2fr)
+    minmax(180px, 1fr)
+    minmax(180px, 1fr)
+    auto;
+  align-items: end;
+  gap: 14px;
+
+  border-radius: 14px;
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.filter-field label {
+  color: #cbd5e1;
+
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.filter-field input,
+.filter-field select {
+  min-height: 42px;
+  padding: 0 12px;
+
+  border: 1px solid #334155;
+  border-radius: 9px;
+
+  background: #07101f;
+  color: #f8fafc;
+
+  outline: none;
+}
+
+.filter-field input:focus,
+.filter-field select:focus {
+  border-color: #f59e0b;
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.12);
+}
+
+.summary-row {
+  margin-bottom: 18px;
+
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.summary-card {
+  min-height: 100px;
+  padding: 18px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  border-radius: 12px;
+}
+
+.summary-card span {
+  color: #94a3b8;
+
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.summary-card strong {
+  color: #f8fafc;
+  font-size: 25px;
+}
+
+.state-card {
+  padding: 32px;
+
+  border-radius: 14px;
+
+  color: #94a3b8;
+  text-align: center;
+}
+
+.table-wrapper {
+  border-radius: 14px;
+  overflow-x: auto;
+}
+
+.users-table {
+  width: 100%;
+
+  border-collapse: collapse;
+
+  color: #e2e8f0;
+}
+
+.users-table th,
+.users-table td {
+  padding: 16px 18px;
+
+  border-bottom: 1px solid #253047;
+
+  text-align: left;
+  vertical-align: middle;
+}
+
+.users-table th {
+  background: #111827;
+  color: #94a3b8;
+
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.users-table tbody tr:hover {
+  background: rgba(30, 41, 59, 0.45);
+}
+
+.users-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.user-identity {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.user-avatar {
+  width: 38px;
+  height: 38px;
+
+  display: grid;
+  place-items: center;
+  flex: 0 0 38px;
+
+  border-radius: 11px;
+
+  background: rgba(245, 158, 11, 0.14);
+  color: #f59e0b;
+
+  font-weight: 900;
+}
+
+.user-identity div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.user-identity strong {
+  color: #f8fafc;
+}
+
+.user-identity small {
+  color: #64748b;
+}
+
+.role-badge,
+.status-badge {
+  display: inline-flex;
+
+  padding: 5px 9px;
+
+  border-radius: 999px;
+
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.admin-role {
+  background: rgba(168, 85, 247, 0.14);
+  color: #d8b4fe;
+}
+
+.operator-role {
+  background: rgba(59, 130, 246, 0.14);
+  color: #93c5fd;
+}
+
+.reader-role {
+  background: rgba(100, 116, 139, 0.18);
+  color: #cbd5e1;
+}
+
+.active-status {
+  background: rgba(34, 197, 94, 0.14);
+  color: #86efac;
+}
+
+.inactive-status {
+  background: rgba(239, 68, 68, 0.14);
+  color: #fca5a5;
+}
+
+.actions-column {
+  text-align: right !important;
+}
+
+.row-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.edit-link,
+.status-button {
+  padding: 8px 11px;
+}
+
+.edit-link {
+  border: 1px solid #334155;
+
+  color: #cbd5e1;
+}
+
+.edit-link:hover {
+  background: #1e293b;
+  color: #ffffff;
+}
+
+.status-button {
+  border: 1px solid transparent;
+}
+
+.disable-button {
+  border-color: rgba(239, 68, 68, 0.45);
+
+  background: rgba(239, 68, 68, 0.1);
+  color: #fca5a5;
+}
+
+.enable-button {
+  border-color: rgba(34, 197, 94, 0.45);
+
+  background: rgba(34, 197, 94, 0.1);
+  color: #86efac;
+}
+
+.status-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+@media (max-width: 1100px) {
+  .filters-card {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .summary-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .page-header {
+    flex-direction: column;
+  }
+
+  .page-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .primary-button,
+  .secondary-button {
+    flex: 1;
+    text-align: center;
+  }
+
+  .filters-card,
+  .summary-row {
+    grid-template-columns: 1fr;
+  }
+
+  .row-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .edit-link,
+  .status-button {
+    text-align: center;
+  }
+}

--- a/frontend/src/app/admin/users/user-list-page/user-list-page.component.html
+++ b/frontend/src/app/admin/users/user-list-page/user-list-page.component.html
@@ -1,0 +1,316 @@
+<section class="users-page">
+
+  <header class="page-header">
+
+    <div>
+      <p class="page-eyebrow">
+        Administration
+      </p>
+
+      <h1>
+        Gestion des utilisateurs
+      </h1>
+
+      <p class="page-description">
+        Créez, modifiez, activez ou désactivez les comptes de Final Space.
+      </p>
+    </div>
+
+    <div class="page-actions">
+
+      <button
+        type="button"
+        class="secondary-button"
+        [disabled]="loading"
+        (click)="loadUsers()"
+      >
+        Actualiser
+      </button>
+
+      <a
+        routerLink="/admin/users/create"
+        class="primary-button"
+      >
+        Créer un utilisateur
+      </a>
+
+    </div>
+
+  </header>
+
+  <div
+    *ngIf="successMessage"
+    class="message-card success-message"
+    role="status"
+  >
+    {{ successMessage }}
+  </div>
+
+  <div
+    *ngIf="errorMessage"
+    class="message-card error-message"
+    role="alert"
+  >
+    {{ errorMessage }}
+  </div>
+
+  <section class="filters-card">
+
+    <div class="filter-field search-field">
+
+      <label for="user-search">
+        Rechercher
+      </label>
+
+      <input
+        id="user-search"
+        type="search"
+        placeholder="Adresse email"
+        [value]="searchTerm"
+        (input)="updateSearchTerm($event)"
+      >
+
+    </div>
+
+    <div class="filter-field">
+
+      <label for="role-filter">
+        Rôle
+      </label>
+
+      <select
+        id="role-filter"
+        [value]="roleFilter"
+        (change)="updateRoleFilter($event)"
+      >
+        <option value="ALL">
+          Tous les rôles
+        </option>
+
+        <option
+          *ngFor="let role of roles"
+          [value]="role"
+        >
+          {{ getRoleLabel(role) }}
+        </option>
+      </select>
+
+    </div>
+
+    <div class="filter-field">
+
+      <label for="status-filter">
+        Statut
+      </label>
+
+      <select
+        id="status-filter"
+        [value]="statusFilter"
+        (change)="updateStatusFilter($event)"
+      >
+        <option value="ALL">
+          Tous les statuts
+        </option>
+
+        <option value="ACTIVE">
+          Actifs
+        </option>
+
+        <option value="INACTIVE">
+          Inactifs
+        </option>
+      </select>
+
+    </div>
+
+    <button
+      type="button"
+      class="reset-button"
+      (click)="resetFilters()"
+    >
+      Réinitialiser
+    </button>
+
+  </section>
+
+  <section class="summary-row">
+
+    <article class="summary-card">
+      <span>Total</span>
+      <strong>{{ users.length }}</strong>
+    </article>
+
+    <article class="summary-card">
+      <span>Actifs</span>
+      <strong>
+        {{ activeUserCount }}
+      </strong>
+    </article>
+
+    <article class="summary-card">
+      <span>Inactifs</span>
+      <strong>
+        {{ inactiveUserCount }}
+      </strong>
+    </article>
+
+    <article class="summary-card">
+      <span>Résultats filtrés</span>
+      <strong>{{ filteredUsers.length }}</strong>
+    </article>
+
+  </section>
+
+  <div
+    *ngIf="loading"
+    class="state-card"
+  >
+    Chargement des utilisateurs...
+  </div>
+
+  <div
+    *ngIf="!loading && users.length === 0"
+    class="state-card"
+  >
+    Aucun utilisateur n’est enregistré.
+  </div>
+
+  <div
+    *ngIf="
+      !loading &&
+      users.length > 0 &&
+      filteredUsers.length === 0
+    "
+    class="state-card"
+  >
+    Aucun utilisateur ne correspond aux filtres sélectionnés.
+  </div>
+
+  <div
+    *ngIf="!loading && filteredUsers.length > 0"
+    class="table-wrapper"
+  >
+
+    <table class="users-table">
+
+      <thead>
+      <tr>
+        <th>Utilisateur</th>
+        <th>Rôle</th>
+        <th>Statut</th>
+        <th>Date de création</th>
+        <th class="actions-column">Actions</th>
+      </tr>
+      </thead>
+
+      <tbody>
+
+      <tr
+        *ngFor="
+            let user of filteredUsers;
+            trackBy: trackByUserId
+          "
+      >
+
+        <td>
+          <div class="user-identity">
+
+              <span class="user-avatar">
+                {{ user.email.charAt(0).toUpperCase() }}
+              </span>
+
+            <div>
+              <strong>
+                {{ user.email }}
+              </strong>
+
+              <small *ngIf="isCurrentUser(user)">
+                Compte actuellement connecté
+              </small>
+            </div>
+
+          </div>
+        </td>
+
+        <td>
+            <span
+              class="role-badge"
+              [class.admin-role]="user.role === 'ADMIN'"
+              [class.operator-role]="user.role === 'OPERATEUR'"
+              [class.reader-role]="user.role === 'LECTEUR'"
+            >
+              {{ getRoleLabel(user.role) }}
+            </span>
+        </td>
+
+        <td>
+            <span
+              class="status-badge"
+              [class.active-status]="user.active"
+              [class.inactive-status]="!user.active"
+            >
+              {{ user.active ? 'Actif' : 'Inactif' }}
+            </span>
+        </td>
+
+        <td>
+          {{ formatDate(user.createdAt) }}
+        </td>
+
+        <td class="actions-column">
+
+          <div class="row-actions">
+
+            <a
+              [routerLink]="[
+                  '/admin/users',
+                  user.id,
+                  'edit'
+                ]"
+              class="edit-link"
+            >
+              Modifier
+            </a>
+
+            <button
+              type="button"
+              class="status-button"
+              [class.enable-button]="!user.active"
+              [class.disable-button]="user.active"
+              [disabled]="
+                  !canChangeStatus(user) ||
+                  updatingUserId === user.id
+                "
+              [title]="
+                  !canChangeStatus(user)
+                    ? 'Vous ne pouvez pas modifier le statut de votre propre compte'
+                    : ''
+                "
+              (click)="toggleStatus(user)"
+            >
+              <ng-container
+                *ngIf="updatingUserId !== user.id"
+              >
+                {{ user.active ? 'Désactiver' : 'Activer' }}
+              </ng-container>
+
+              <ng-container
+                *ngIf="updatingUserId === user.id"
+              >
+                Traitement...
+              </ng-container>
+            </button>
+
+          </div>
+
+        </td>
+
+      </tr>
+
+      </tbody>
+
+    </table>
+
+  </div>
+
+</section>

--- a/frontend/src/app/admin/users/user-list-page/user-list-page.component.spec.ts
+++ b/frontend/src/app/admin/users/user-list-page/user-list-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserListPageComponent } from './user-list-page.component';
+
+describe('UserListPageComponent', () => {
+  let component: UserListPageComponent;
+  let fixture: ComponentFixture<UserListPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserListPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(UserListPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/admin/users/user-list-page/user-list-page.component.ts
+++ b/frontend/src/app/admin/users/user-list-page/user-list-page.component.ts
@@ -1,0 +1,260 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { AuthService } from '../../../auth/auth.service';
+import {
+  User,
+  UserRole
+} from '../models/user.model';
+import { UserService } from '../services/user.service';
+
+type StatusFilter = 'ALL' | 'ACTIVE' | 'INACTIVE';
+type RoleFilter = 'ALL' | UserRole;
+
+@Component({
+  selector: 'app-user-list-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink
+  ],
+  templateUrl: './user-list-page.component.html',
+  styleUrl: './user-list-page.component.css'
+})
+export class UserListPageComponent implements OnInit {
+
+  private readonly userService = inject(UserService);
+  private readonly authService = inject(AuthService);
+
+  users: User[] = [];
+
+  loading = false;
+  errorMessage = '';
+  successMessage = '';
+
+  roleFilter: RoleFilter = 'ALL';
+  statusFilter: StatusFilter = 'ALL';
+  searchTerm = '';
+
+  updatingUserId: number | null = null;
+
+  readonly roles: UserRole[] = [
+    'ADMIN',
+    'OPERATEUR',
+    'LECTEUR'
+  ];
+
+  ngOnInit(): void {
+    this.loadUsers();
+  }
+
+  get currentUserEmail(): string | null {
+    return this.authService.getUserEmail();
+  }
+
+  get filteredUsers(): User[] {
+    const normalizedSearch = this.searchTerm
+      .trim()
+      .toLowerCase();
+
+    return this.users.filter((user) => {
+      const matchesSearch =
+        !normalizedSearch ||
+        user.email.toLowerCase().includes(normalizedSearch);
+
+      const matchesRole =
+        this.roleFilter === 'ALL' ||
+        user.role === this.roleFilter;
+
+      const matchesStatus =
+        this.statusFilter === 'ALL' ||
+        (this.statusFilter === 'ACTIVE' && user.active) ||
+        (this.statusFilter === 'INACTIVE' && !user.active);
+
+      return matchesSearch && matchesRole && matchesStatus;
+    });
+  }
+
+  get activeUserCount(): number {
+    return this.users.filter((user) => user.active).length;
+  }
+
+  get inactiveUserCount(): number {
+    return this.users.filter((user) => !user.active).length;
+  }
+
+  loadUsers(): void {
+    this.loading = true;
+    this.errorMessage = '';
+    this.successMessage = '';
+
+    this.userService.getUsers().subscribe({
+      next: (users) => {
+        this.users = [...users].sort((first, second) =>
+          first.email.localeCompare(second.email)
+        );
+
+        this.loading = false;
+      },
+      error: (error) => {
+        this.errorMessage = this.extractErrorMessage(
+          error,
+          'Impossible de charger les utilisateurs.'
+        );
+
+        this.loading = false;
+      }
+    });
+  }
+
+  updateSearchTerm(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.searchTerm = input.value;
+  }
+
+  updateRoleFilter(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    this.roleFilter = select.value as RoleFilter;
+  }
+
+  updateStatusFilter(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    this.statusFilter = select.value as StatusFilter;
+  }
+
+  resetFilters(): void {
+    this.searchTerm = '';
+    this.roleFilter = 'ALL';
+    this.statusFilter = 'ALL';
+  }
+
+  isCurrentUser(user: User): boolean {
+    return user.email === this.currentUserEmail;
+  }
+
+  canChangeStatus(user: User): boolean {
+    return !this.isCurrentUser(user);
+  }
+
+  toggleStatus(user: User): void {
+    if (!this.canChangeStatus(user)) {
+      this.errorMessage =
+        'Vous ne pouvez pas désactiver votre propre compte administrateur.';
+      return;
+    }
+
+    const nextStatus = !user.active;
+    const actionLabel = nextStatus ? 'activer' : 'désactiver';
+
+    const confirmed = window.confirm(
+      `Voulez-vous vraiment ${actionLabel} le compte ${user.email} ?`
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    this.updatingUserId = user.id;
+    this.errorMessage = '';
+    this.successMessage = '';
+
+    this.userService.updateStatus(user.id, nextStatus).subscribe({
+      next: (updatedUser) => {
+        this.users = this.users.map((currentUser) =>
+          currentUser.id === updatedUser.id
+            ? updatedUser
+            : currentUser
+        );
+
+        this.successMessage = nextStatus
+          ? `Le compte ${updatedUser.email} a été activé.`
+          : `Le compte ${updatedUser.email} a été désactivé.`;
+
+        this.updatingUserId = null;
+      },
+      error: (error) => {
+        this.errorMessage = this.extractErrorMessage(
+          error,
+          `Impossible de ${actionLabel} le compte.`
+        );
+
+        this.updatingUserId = null;
+      }
+    });
+  }
+
+  getRoleLabel(role: UserRole): string {
+    switch (role) {
+      case 'ADMIN':
+        return 'Administrateur';
+      case 'OPERATEUR':
+        return 'Opérateur';
+      case 'LECTEUR':
+        return 'Lecteur';
+    }
+  }
+
+  formatDate(value: string): string {
+    if (!value) {
+      return 'Non renseignée';
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+
+    return new Intl.DateTimeFormat('fr-FR', {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(date);
+  }
+
+  trackByUserId(
+    index: number,
+    user: User
+  ): number {
+    return user.id;
+  }
+
+  private extractErrorMessage(
+    error: unknown,
+    fallbackMessage: string
+  ): string {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'error' in error
+    ) {
+      const responseBody = (
+        error as {
+          error?: unknown;
+        }
+      ).error;
+
+      if (typeof responseBody === 'string' && responseBody.trim()) {
+        return responseBody;
+      }
+
+      if (
+        typeof responseBody === 'object' &&
+        responseBody !== null &&
+        'message' in responseBody
+      ) {
+        const message = (
+          responseBody as {
+            message?: unknown;
+          }
+        ).message;
+
+        if (typeof message === 'string' && message.trim()) {
+          return message;
+        }
+      }
+    }
+
+    return fallbackMessage;
+  }
+}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -16,6 +16,10 @@ import { AlertListPageComponent } from './alerts/alert-list-page/alert-list-page
 import { IncidentListPageComponent } from './incidents/incident-list-page/incident-list-page.component';
 import { ReportPageComponent } from './reports/report-page/report-page.component';
 
+import { adminGuard } from './auth/admin.guard';
+import { UserListPageComponent } from './admin/users/user-list-page/user-list-page.component';
+import { UserFormPageComponent } from './admin/users/user-form-page/user-form-page.component';
+
 import { AppShellComponent } from './layout/app-shell/app-shell.component';
 
 export const routes: Routes = [
@@ -39,6 +43,21 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./dashboard/dashboard.component')
             .then(m => m.DashboardComponent)
+      },
+      {
+        path: 'admin/users',
+        canActivate: [adminGuard],
+        component: UserListPageComponent
+      },
+      {
+        path: 'admin/users/create',
+        canActivate: [adminGuard],
+        component: UserFormPageComponent
+      },
+      {
+        path: 'admin/users/:id/edit',
+        canActivate: [adminGuard],
+        component: UserFormPageComponent
       },
       {
         path: 'missions',

--- a/frontend/src/app/auth/admin.guard.ts
+++ b/frontend/src/app/auth/admin.guard.ts
@@ -1,0 +1,19 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { AuthService } from './auth.service';
+
+export const adminGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
+  }
+
+  if (!authService.isAdmin()) {
+    return router.createUrlTree(['/forbidden']);
+  }
+
+  return true;
+};

--- a/frontend/src/app/layout/app-sidebar/app-sidebar.component.ts
+++ b/frontend/src/app/layout/app-sidebar/app-sidebar.component.ts
@@ -1,12 +1,15 @@
-import { Component, Input } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { NgClass, NgFor } from '@angular/common';
 import { RouterLink, RouterLinkActive } from '@angular/router';
+
+import { AuthService } from '../../auth/auth.service';
 
 interface NavigationItem {
   label: string;
   description: string;
   route: string;
   icon: string;
+  adminOnly?: boolean;
 }
 
 @Component({
@@ -23,15 +26,17 @@ interface NavigationItem {
 })
 export class AppSidebarComponent {
 
+  private readonly authService = inject(AuthService);
+
   @Input()
   collapsed = false;
 
   readonly items: NavigationItem[] = [
     {
-      label: 'Vue générale',
-      description: 'Synthèse opérationnelle',
+      label: 'Vue g\u00e9n\u00e9rale',
+      description: 'Synth\u00e8se op\u00e9rationnelle',
       route: '/dashboard',
-      icon: '⌂'
+      icon: '\u2302'
     },
     {
       label: 'Missions',
@@ -52,14 +57,14 @@ export class AppSidebarComponent {
       icon: 'SIM'
     },
     {
-      label: 'Télémétrie',
+      label: 'T\u00e9l\u00e9m\u00e9trie',
       description: 'Mesures et anomalies',
       route: '/telemetry',
       icon: 'T'
     },
     {
       label: 'Alertes',
-      description: 'Alertes opérationnelles',
+      description: 'Alertes op\u00e9rationnelles',
       route: '/alerts',
       icon: 'A'
     },
@@ -74,6 +79,19 @@ export class AppSidebarComponent {
       description: 'Exports et rapports',
       route: '/reports',
       icon: 'R'
+    },
+    {
+      label: 'Utilisateurs',
+      description: 'Administration des comptes',
+      route: '/admin/users',
+      icon: 'U',
+      adminOnly: true
     }
   ];
+
+  get visibleItems(): NavigationItem[] {
+    return this.items.filter(
+      item => !item.adminOnly || this.authService.isAdmin()
+    );
+  }
 }


### PR DESCRIPTION
## Objectif

Ajouter une gestion complète des utilisateurs réservée au rôle ADMIN.

## Fonctionnalités

- liste des utilisateurs ;
- filtres par email, rôle et statut ;
- création d’un utilisateur ;
- modification de l’email et du rôle ;
- activation et désactivation d’un compte ;
- protection des routes avec `adminGuard` ;
- accès backend limité à `ROLE_ADMIN` ;
- interdiction de connexion pour les comptes désactivés ;
- ajout de l’entrée Utilisateurs dans la navigation administrateur.

## Validation

- build backend réussi ;
- endpoints utilisateurs validés ;
- doublon email retourné en 409 ;
- utilisateur inexistant retourné en 404 ;
- accès OPERATEUR refusé en 403 ;
- compte désactivé refusé en 401 ;
- build frontend réussi ;
- parcours création, modification et changement de statut validés.