### PR TITLE
refactor(frontend): share mission satellite selection

### DIFF
--- a/frontend/src/app/reports/report-page/report-page.component.html
+++ b/frontend/src/app/reports/report-page/report-page.component.html
@@ -72,65 +72,16 @@
 
     <div class="context-grid">
 
-      <div class="form-field">
-
-        <label for="mission-select">
-          Mission
-        </label>
-
-        <select
-          id="mission-select"
-          [(ngModel)]="selectedMissionId"
-          [disabled]="
-            missionsLoading ||
-            missions.length === 0
-          "
-          (change)="onMissionChange()"
-        >
-          <option
-            *ngFor="
-              let mission of missions;
-              trackBy: trackByMissionId
-            "
-            [ngValue]="mission.id"
-          >
-            {{ mission.name }}
-            —
-            {{ mission.status === 'ACTIVE' ? 'Active' : 'Clôturée' }}
-          </option>
-        </select>
-
-      </div>
-
-      <div class="form-field">
-
-        <label for="satellite-select">
-          Satellite
-        </label>
-
-        <select
-          id="satellite-select"
-          [(ngModel)]="selectedSatelliteId"
-          [disabled]="
-            satellitesLoading ||
-            satellites.length === 0
-          "
-          (change)="onSatelliteChange()"
-        >
-          <option
-            *ngFor="
-              let satellite of satellites;
-              trackBy: trackBySatelliteId
-            "
-            [ngValue]="satellite.id"
-          >
-            {{ satellite.name }}
-            —
-            {{ satellite.status === 'ACTIF' ? 'Actif' : 'Inactif' }}
-          </option>
-        </select>
-
-      </div>
+      <app-mission-satellite-selector
+        [missions]="missions"
+        [satellites]="satellites"
+        [missionsLoading]="missionsLoading"
+        [satellitesLoading]="satellitesLoading"
+        [(selectedMissionId)]="selectedMissionId"
+        [(selectedSatelliteId)]="selectedSatelliteId"
+        (missionChange)="onMissionChange()"
+        (satelliteChange)="onSatelliteChange()"
+      />
 
     </div>
 

--- a/frontend/src/app/reports/report-page/report-page.component.ts
+++ b/frontend/src/app/reports/report-page/report-page.component.ts
@@ -12,6 +12,12 @@ import { MissionService } from '../../missions/services/mission.service';
 import { Satellite } from '../../satellites/models/satellite.model';
 import { SatelliteService } from '../../satellites/services/satellite.service';
 import {
+  MissionSatelliteSelectorComponent
+} from '../../shared/mission-satellite-selector/mission-satellite-selector.component';
+import {
+  MissionSatelliteContextService
+} from '../../shared/services/mission-satellite-context.service';
+import {
   SimulationListItemResponse,
   SimulationType
 } from '../../simulations/models/simulation.model';
@@ -26,7 +32,8 @@ type ExportFormat = 'csv' | 'pdf';
   imports: [
     CommonModule,
     FormsModule,
-    RouterLink
+    RouterLink,
+    MissionSatelliteSelectorComponent
   ],
   templateUrl: './report-page.component.html',
   styleUrl: './report-page.component.css'
@@ -35,6 +42,8 @@ export class ReportPageComponent implements OnInit {
 
   private readonly missionService = inject(MissionService);
   private readonly satelliteService = inject(SatelliteService);
+  private readonly contextService =
+    inject(MissionSatelliteContextService);
   private readonly simulationService = inject(SimulationService);
   private readonly telemetryService = inject(TelemetryService);
   private readonly route = inject(ActivatedRoute);
@@ -106,10 +115,8 @@ export class ReportPageComponent implements OnInit {
 
     this.missionService.findAll().subscribe({
       next: missions => {
-        this.missions = [...missions].sort(
-          (first, second) =>
-            first.name.localeCompare(second.name)
-        );
+        this.missions =
+          this.contextService.sortMissions(missions);
 
         this.missionsLoading = false;
         this.initializeMissionSelection();
@@ -153,10 +160,8 @@ export class ReportPageComponent implements OnInit {
 
     this.satelliteService.findByMission(missionId).subscribe({
       next: satellites => {
-        this.satellites = [...satellites].sort(
-          (first, second) =>
-            first.name.localeCompare(second.name)
-        );
+        this.satellites =
+          this.contextService.sortSatellites(satellites);
 
         this.satellitesLoading = false;
         this.initializeSatelliteSelection();

--- a/frontend/src/app/shared/mission-satellite-selector/mission-satellite-selector.component.css
+++ b/frontend/src/app/shared/mission-satellite-selector/mission-satellite-selector.component.css
@@ -1,0 +1,25 @@
+﻿.mission-satellite-selector {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+.form-field select {
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .mission-satellite-selector {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/shared/mission-satellite-selector/mission-satellite-selector.component.html
+++ b/frontend/src/app/shared/mission-satellite-selector/mission-satellite-selector.component.html
@@ -1,0 +1,65 @@
+﻿<div class="mission-satellite-selector">
+  <div class="form-field">
+    <label for="mission-select">
+      Mission
+    </label>
+
+    <select
+      id="mission-select"
+      [ngModel]="selectedMissionId"
+      [disabled]="
+        missionsLoading ||
+        missions.length === 0
+      "
+      (ngModelChange)="onMissionSelectionChange($event)"
+    >
+      <option
+        *ngFor="
+          let mission of missions;
+          trackBy: trackByMissionId
+        "
+        [ngValue]="mission.id"
+      >
+        {{ mission.name }}
+        —
+        {{
+          mission.status === 'ACTIVE'
+            ? 'Active'
+            : 'Clôturée'
+        }}
+      </option>
+    </select>
+  </div>
+
+  <div class="form-field">
+    <label for="satellite-select">
+      Satellite
+    </label>
+
+    <select
+      id="satellite-select"
+      [ngModel]="selectedSatelliteId"
+      [disabled]="
+        satellitesLoading ||
+        satellites.length === 0
+      "
+      (ngModelChange)="onSatelliteSelectionChange($event)"
+    >
+      <option
+        *ngFor="
+          let satellite of satellites;
+          trackBy: trackBySatelliteId
+        "
+        [ngValue]="satellite.id"
+      >
+        {{ satellite.name }}
+        —
+        {{
+          satellite.status === 'ACTIF'
+            ? 'Actif'
+            : 'Inactif'
+        }}
+      </option>
+    </select>
+  </div>
+</div>

--- a/frontend/src/app/shared/mission-satellite-selector/mission-satellite-selector.component.spec.ts
+++ b/frontend/src/app/shared/mission-satellite-selector/mission-satellite-selector.component.spec.ts
@@ -1,0 +1,171 @@
+﻿import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import { Mission } from '../../missions/models/mission.model';
+import { Satellite } from '../../satellites/models/satellite.model';
+import {
+  MissionSatelliteSelectorComponent
+} from './mission-satellite-selector.component';
+
+describe('MissionSatelliteSelectorComponent', () => {
+  let component: MissionSatelliteSelectorComponent;
+  let fixture: ComponentFixture<
+    MissionSatelliteSelectorComponent
+  >;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        MissionSatelliteSelectorComponent
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(
+      MissionSatelliteSelectorComponent
+    );
+
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit the selected mission', () => {
+    spyOn(
+      component.selectedMissionIdChange,
+      'emit'
+    );
+
+    spyOn(
+      component.missionChange,
+      'emit'
+    );
+
+    component.onMissionSelectionChange(12);
+
+    expect(component.selectedMissionId).toBe(12);
+
+    expect(
+      component.selectedMissionIdChange.emit
+    ).toHaveBeenCalledWith(12);
+
+    expect(
+      component.missionChange.emit
+    ).toHaveBeenCalled();
+  });
+
+  it('should emit a null mission selection', () => {
+    spyOn(
+      component.selectedMissionIdChange,
+      'emit'
+    );
+
+    component.onMissionSelectionChange(null);
+
+    expect(component.selectedMissionId).toBeNull();
+
+    expect(
+      component.selectedMissionIdChange.emit
+    ).toHaveBeenCalledWith(null);
+  });
+
+  it('should emit the selected satellite', () => {
+    spyOn(
+      component.selectedSatelliteIdChange,
+      'emit'
+    );
+
+    spyOn(
+      component.satelliteChange,
+      'emit'
+    );
+
+    component.onSatelliteSelectionChange(24);
+
+    expect(component.selectedSatelliteId).toBe(24);
+
+    expect(
+      component.selectedSatelliteIdChange.emit
+    ).toHaveBeenCalledWith(24);
+
+    expect(
+      component.satelliteChange.emit
+    ).toHaveBeenCalled();
+  });
+
+  it('should emit a null satellite selection', () => {
+    spyOn(
+      component.selectedSatelliteIdChange,
+      'emit'
+    );
+
+    component.onSatelliteSelectionChange(null);
+
+    expect(component.selectedSatelliteId).toBeNull();
+
+    expect(
+      component.selectedSatelliteIdChange.emit
+    ).toHaveBeenCalledWith(null);
+  });
+
+  it('should track missions by id', () => {
+    const mission = {
+      id: 7,
+      name: 'Mission test'
+    } as Mission;
+
+    expect(
+      component.trackByMissionId(0, mission)
+    ).toBe(7);
+  });
+
+  it('should track satellites by id', () => {
+    const satellite = {
+      id: 9,
+      name: 'Satellite test'
+    } as Satellite;
+
+    expect(
+      component.trackBySatelliteId(0, satellite)
+    ).toBe(9);
+  });
+
+  it('should display the mission and satellite selectors', () => {
+    component.missions = [
+      {
+        id: 1,
+        name: 'Mission Alpha',
+        status: 'ACTIVE'
+      }
+    ] as Mission[];
+
+    component.satellites = [
+      {
+        id: 2,
+        name: 'Satellite Alpha',
+        status: 'ACTIF'
+      }
+    ] as Satellite[];
+
+    fixture.detectChanges();
+
+    const element =
+      fixture.nativeElement as HTMLElement;
+
+    expect(
+      element.querySelector('#mission-select')
+    ).toBeTruthy();
+
+    expect(
+      element.querySelector('#satellite-select')
+    ).toBeTruthy();
+
+    expect(element.textContent)
+      .toContain('Mission Alpha');
+
+    expect(element.textContent)
+      .toContain('Satellite Alpha');
+  });
+});

--- a/frontend/src/app/shared/mission-satellite-selector/mission-satellite-selector.component.ts
+++ b/frontend/src/app/shared/mission-satellite-selector/mission-satellite-selector.component.ts
@@ -1,0 +1,72 @@
+﻿import { CommonModule } from '@angular/common';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Mission } from '../../missions/models/mission.model';
+import { Satellite } from '../../satellites/models/satellite.model';
+
+@Component({
+  selector: 'app-mission-satellite-selector',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  templateUrl:
+    './mission-satellite-selector.component.html',
+  styleUrl:
+    './mission-satellite-selector.component.css'
+})
+export class MissionSatelliteSelectorComponent {
+  @Input() missions: Mission[] = [];
+  @Input() satellites: Satellite[] = [];
+
+  @Input() selectedMissionId: number | null = null;
+  @Input() selectedSatelliteId: number | null = null;
+
+  @Input() missionsLoading = false;
+  @Input() satellitesLoading = false;
+
+  @Output() selectedMissionIdChange =
+    new EventEmitter<number | null>();
+
+  @Output() selectedSatelliteIdChange =
+    new EventEmitter<number | null>();
+
+  @Output() missionChange = new EventEmitter<void>();
+  @Output() satelliteChange = new EventEmitter<void>();
+
+  onMissionSelectionChange(
+    missionId: number | null
+  ): void {
+    this.selectedMissionId = missionId;
+    this.selectedMissionIdChange.emit(missionId);
+    this.missionChange.emit();
+  }
+
+  onSatelliteSelectionChange(
+    satelliteId: number | null
+  ): void {
+    this.selectedSatelliteId = satelliteId;
+    this.selectedSatelliteIdChange.emit(satelliteId);
+    this.satelliteChange.emit();
+  }
+
+  trackByMissionId(
+    index: number,
+    mission: Mission
+  ): number {
+    return mission.id;
+  }
+
+  trackBySatelliteId(
+    index: number,
+    satellite: Satellite
+  ): number {
+    return satellite.id;
+  }
+}

--- a/frontend/src/app/shared/services/mission-satellite-context.service.spec.ts
+++ b/frontend/src/app/shared/services/mission-satellite-context.service.spec.ts
@@ -1,0 +1,142 @@
+﻿import { TestBed } from '@angular/core/testing';
+import { Mission } from '../../missions/models/mission.model';
+import { Satellite } from '../../satellites/models/satellite.model';
+import { MissionSatelliteContextService } from './mission-satellite-context.service';
+
+describe('MissionSatelliteContextService', () => {
+  let service: MissionSatelliteContextService;
+
+  const createMission = (
+    id: number,
+    name: string,
+    status: Mission['status']
+  ): Mission => ({
+    id,
+    name,
+    status,
+    createdAt: '2026-07-20T00:00:00Z'
+  });
+
+  const createSatellite = (
+    id: number,
+    name: string,
+    status: Satellite['status']
+  ): Satellite => ({
+    id,
+    name,
+    status
+  } as Satellite);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+
+    service = TestBed.inject(
+      MissionSatelliteContextService
+    );
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should sort missions by name without modifying the source array', () => {
+    const missions = [
+      createMission(2, 'Zulu', 'CLOTUREE'),
+      createMission(1, 'Alpha', 'ACTIVE')
+    ];
+
+    const result = service.sortMissions(missions);
+
+    expect(result.map(mission => mission.name))
+      .toEqual(['Alpha', 'Zulu']);
+
+    expect(missions.map(mission => mission.name))
+      .toEqual(['Zulu', 'Alpha']);
+  });
+
+  it('should select the requested mission', () => {
+    const missions = [
+      createMission(1, 'Mission A', 'ACTIVE'),
+      createMission(2, 'Mission B', 'CLOTUREE')
+    ];
+
+    expect(service.selectMission(missions, 2)?.id)
+      .toBe(2);
+  });
+
+  it('should select an active mission when the requested mission is absent', () => {
+    const missions = [
+      createMission(1, 'Mission A', 'CLOTUREE'),
+      createMission(2, 'Mission B', 'ACTIVE')
+    ];
+
+    expect(service.selectMission(missions, 99)?.id)
+      .toBe(2);
+  });
+
+  it('should select the first mission when none is active', () => {
+    const missions = [
+      createMission(1, 'Mission A', 'CLOTUREE'),
+      createMission(2, 'Mission B', 'CLOTUREE')
+    ];
+
+    expect(service.selectMission(missions, null)?.id)
+      .toBe(1);
+  });
+
+  it('should return null when the mission list is empty', () => {
+    expect(service.selectMission([], null))
+      .toBeNull();
+  });
+
+  it('should sort satellites by name without modifying the source array', () => {
+    const satellites = [
+      createSatellite(2, 'Zulu Sat', 'INACTIF'),
+      createSatellite(1, 'Alpha Sat', 'ACTIF')
+    ];
+
+    const result = service.sortSatellites(satellites);
+
+    expect(result.map(satellite => satellite.name))
+      .toEqual(['Alpha Sat', 'Zulu Sat']);
+
+    expect(satellites.map(satellite => satellite.name))
+      .toEqual(['Zulu Sat', 'Alpha Sat']);
+  });
+
+  it('should select the requested satellite', () => {
+    const satellites = [
+      createSatellite(1, 'Satellite A', 'ACTIF'),
+      createSatellite(2, 'Satellite B', 'INACTIF')
+    ];
+
+    expect(service.selectSatellite(satellites, 2)?.id)
+      .toBe(2);
+  });
+
+  it('should select an active satellite when the requested satellite is absent', () => {
+    const satellites = [
+      createSatellite(1, 'Satellite A', 'INACTIF'),
+      createSatellite(2, 'Satellite B', 'ACTIF')
+    ];
+
+    expect(service.selectSatellite(satellites, 99)?.id)
+      .toBe(2);
+  });
+
+  it('should select the first satellite when none is active', () => {
+    const satellites = [
+      createSatellite(1, 'Satellite A', 'INACTIF'),
+      createSatellite(2, 'Satellite B', 'INACTIF')
+    ];
+
+    expect(service.selectSatellite(satellites, null)?.id)
+      .toBe(1);
+  });
+
+  it('should return null when the satellite list is empty', () => {
+    expect(service.selectSatellite([], null))
+      .toBeNull();
+  });
+});
+

--- a/frontend/src/app/shared/services/mission-satellite-context.service.ts
+++ b/frontend/src/app/shared/services/mission-satellite-context.service.ts
@@ -1,0 +1,54 @@
+﻿import { Injectable } from '@angular/core';
+import { Mission } from '../../missions/models/mission.model';
+import { Satellite } from '../../satellites/models/satellite.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MissionSatelliteContextService {
+  sortMissions(missions: Mission[]): Mission[] {
+    return [...missions].sort(
+      (first, second) => first.name.localeCompare(second.name)
+    );
+  }
+
+  sortSatellites(satellites: Satellite[]): Satellite[] {
+    return [...satellites].sort(
+      (first, second) => first.name.localeCompare(second.name)
+    );
+  }
+
+  selectMission(
+    missions: Mission[],
+    requestedId: number | null
+  ): Mission | null {
+    if (missions.length === 0) {
+      return null;
+    }
+
+    return (
+      missions.find(mission => mission.id === requestedId) ??
+      missions.find(mission => mission.status === 'ACTIVE') ??
+      missions[0]
+    );
+  }
+
+  selectSatellite(
+    satellites: Satellite[],
+    requestedId: number | null
+  ): Satellite | null {
+    if (satellites.length === 0) {
+      return null;
+    }
+
+    return (
+      satellites.find(
+        satellite => satellite.id === requestedId
+      ) ??
+      satellites.find(
+        satellite => satellite.status === 'ACTIF'
+      ) ??
+      satellites[0]
+    );
+  }
+}

--- a/frontend/src/app/simulations/simulation-list-page/simulation-list-page.component.html
+++ b/frontend/src/app/simulations/simulation-list-page/simulation-list-page.component.html
@@ -94,62 +94,16 @@
 
     <div class="selection-grid">
 
-      <div class="form-field">
-
-        <label for="mission-select">
-          Mission
-        </label>
-
-        <select
-          id="mission-select"
-          [(ngModel)]="selectedMissionId"
-          [disabled]="missionsLoading || missions.length === 0"
-          (change)="onMissionChange()"
-        >
-          <option
-            *ngFor="
-              let mission of missions;
-              trackBy: trackByMissionId
-            "
-            [ngValue]="mission.id"
-          >
-            {{ mission.name }}
-            —
-            {{ mission.status === 'ACTIVE' ? 'Active' : 'Clôturée' }}
-          </option>
-        </select>
-
-      </div>
-
-      <div class="form-field">
-
-        <label for="satellite-select">
-          Satellite
-        </label>
-
-        <select
-          id="satellite-select"
-          [(ngModel)]="selectedSatelliteId"
-          [disabled]="
-            satellitesLoading ||
-            satellites.length === 0
-          "
-          (change)="onSatelliteChange()"
-        >
-          <option
-            *ngFor="
-              let satellite of satellites;
-              trackBy: trackBySatelliteId
-            "
-            [ngValue]="satellite.id"
-          >
-            {{ satellite.name }}
-            —
-            {{ satellite.status === 'ACTIF' ? 'Actif' : 'Inactif' }}
-          </option>
-        </select>
-
-      </div>
+      <app-mission-satellite-selector
+        [missions]="missions"
+        [satellites]="satellites"
+        [missionsLoading]="missionsLoading"
+        [satellitesLoading]="satellitesLoading"
+        [(selectedMissionId)]="selectedMissionId"
+        [(selectedSatelliteId)]="selectedSatelliteId"
+        (missionChange)="onMissionChange()"
+        (satelliteChange)="onSatelliteChange()"
+      />
 
     </div>
 

--- a/frontend/src/app/simulations/simulation-list-page/simulation-list-page.component.ts
+++ b/frontend/src/app/simulations/simulation-list-page/simulation-list-page.component.ts
@@ -13,6 +13,12 @@ import { MissionService } from '../../missions/services/mission.service';
 import { Satellite } from '../../satellites/models/satellite.model';
 import { SatelliteService } from '../../satellites/services/satellite.service';
 import {
+  MissionSatelliteSelectorComponent
+} from '../../shared/mission-satellite-selector/mission-satellite-selector.component';
+import {
+  MissionSatelliteContextService
+} from '../../shared/services/mission-satellite-context.service';
+import {
   SimulationListItemResponse,
   SimulationResponse,
   SimulationStatus,
@@ -29,7 +35,8 @@ type SimulationStatusFilter = 'ALL' | SimulationStatus;
   imports: [
     CommonModule,
     FormsModule,
-    RouterLink
+    RouterLink,
+    MissionSatelliteSelectorComponent
   ],
   templateUrl: './simulation-list-page.component.html',
   styleUrl: './simulation-list-page.component.css'
@@ -38,6 +45,8 @@ export class SimulationListPageComponent implements OnInit {
 
   private readonly missionService = inject(MissionService);
   private readonly satelliteService = inject(SatelliteService);
+  private readonly contextService =
+    inject(MissionSatelliteContextService);
   private readonly simulationService = inject(SimulationService);
   private readonly authService = inject(AuthService);
   private readonly route = inject(ActivatedRoute);
@@ -160,10 +169,8 @@ export class SimulationListPageComponent implements OnInit {
 
     this.missionService.findAll().subscribe({
       next: missions => {
-        this.missions = [...missions].sort(
-          (first, second) =>
-            first.name.localeCompare(second.name)
-        );
+        this.missions =
+          this.contextService.sortMissions(missions);
 
         this.missionsLoading = false;
         this.initializeMissionSelection();
@@ -208,10 +215,8 @@ export class SimulationListPageComponent implements OnInit {
 
     this.satelliteService.findByMission(missionId).subscribe({
       next: satellites => {
-        this.satellites = [...satellites].sort(
-          (first, second) =>
-            first.name.localeCompare(second.name)
-        );
+        this.satellites =
+          this.contextService.sortSatellites(satellites);
 
         this.satellitesLoading = false;
         this.initializeSatelliteSelection();

--- a/frontend/src/app/telemetry/telemetry-page/telemetry-page.component.html
+++ b/frontend/src/app/telemetry/telemetry-page/telemetry-page.component.html
@@ -56,51 +56,16 @@
     </div>
 
     <div class="context-grid">
-      <div class="form-field">
-        <label for="mission-select">Mission</label>
-
-        <select
-          id="mission-select"
-          [(ngModel)]="selectedMissionId"
-          [disabled]="missionsLoading || missions.length === 0"
-          (change)="onMissionChange()"
-        >
-          <option
-            *ngFor="
-              let mission of missions;
-              trackBy: trackByMissionId
-            "
-            [ngValue]="mission.id"
-          >
-            {{ mission.name }}
-            —
-            {{ mission.status === 'ACTIVE' ? 'Active' : 'Clôturée' }}
-          </option>
-        </select>
-      </div>
-
-      <div class="form-field">
-        <label for="satellite-select">Satellite</label>
-
-        <select
-          id="satellite-select"
-          [(ngModel)]="selectedSatelliteId"
-          [disabled]="satellitesLoading || satellites.length === 0"
-          (change)="onSatelliteChange()"
-        >
-          <option
-            *ngFor="
-              let satellite of satellites;
-              trackBy: trackBySatelliteId
-            "
-            [ngValue]="satellite.id"
-          >
-            {{ satellite.name }}
-            —
-            {{ satellite.status === 'ACTIF' ? 'Actif' : 'Inactif' }}
-          </option>
-        </select>
-      </div>
+      <app-mission-satellite-selector
+        [missions]="missions"
+        [satellites]="satellites"
+        [missionsLoading]="missionsLoading"
+        [satellitesLoading]="satellitesLoading"
+        [(selectedMissionId)]="selectedMissionId"
+        [(selectedSatelliteId)]="selectedSatelliteId"
+        (missionChange)="onMissionChange()"
+        (satelliteChange)="onSatelliteChange()"
+      />
     </div>
   </section>
 

--- a/frontend/src/app/telemetry/telemetry-page/telemetry-page.component.ts
+++ b/frontend/src/app/telemetry/telemetry-page/telemetry-page.component.ts
@@ -13,6 +13,12 @@ import { MissionService } from '../../missions/services/mission.service';
 import { Satellite } from '../../satellites/models/satellite.model';
 import { SatelliteService } from '../../satellites/services/satellite.service';
 import {
+  MissionSatelliteSelectorComponent
+} from '../../shared/mission-satellite-selector/mission-satellite-selector.component';
+import {
+  MissionSatelliteContextService
+} from '../../shared/services/mission-satellite-context.service';
+import {
   TelemetryAnomaly,
   TelemetryAnomalySeverity,
   TelemetryAnomalyType
@@ -43,7 +49,8 @@ interface TelemetryChartSeries {
   imports: [
     CommonModule,
     FormsModule,
-    RouterLink
+    RouterLink,
+    MissionSatelliteSelectorComponent
   ],
   templateUrl: './telemetry-page.component.html',
   styleUrl: './telemetry-page.component.css'
@@ -52,6 +59,8 @@ export class TelemetryPageComponent implements OnInit {
 
   private readonly missionService = inject(MissionService);
   private readonly satelliteService = inject(SatelliteService);
+  private readonly contextService =
+    inject(MissionSatelliteContextService);
   private readonly telemetryService = inject(TelemetryService);
   private readonly authService = inject(AuthService);
   private readonly route = inject(ActivatedRoute);
@@ -154,10 +163,8 @@ export class TelemetryPageComponent implements OnInit {
 
     this.missionService.findAll().subscribe({
       next: missions => {
-        this.missions = [...missions].sort(
-          (first, second) =>
-            first.name.localeCompare(second.name)
-        );
+        this.missions =
+          this.contextService.sortMissions(missions);
 
         this.missionsLoading = false;
         this.initializeMissionSelection();
@@ -193,10 +200,8 @@ export class TelemetryPageComponent implements OnInit {
 
     this.satelliteService.findByMission(missionId).subscribe({
       next: satellites => {
-        this.satellites = [...satellites].sort(
-          (first, second) =>
-            first.name.localeCompare(second.name)
-        );
+        this.satellites =
+          this.contextService.sortSatellites(satellites);
 
         this.satellitesLoading = false;
         this.initializeSatelliteSelection();


### PR DESCRIPTION
## Objectif

Réduire les duplications détectées par Sonar dans les pages
Télémétrie, Simulations et Rapports.

## Modifications

- création d’un composant partagé de sélection Mission / Satellite ;
- création d’un service partagé pour le tri et la sélection par défaut ;
- intégration dans les pages Télémétrie, Simulations et Rapports ;
- ajout des tests unitaires du composant et du service.

## Vérifications

- 423 tests frontend réussis ;
- couverture globale supérieure à 87 % ;
- build Angular réussi.